### PR TITLE
Fix usage when body is binary

### DIFF
--- a/cassette.go
+++ b/cassette.go
@@ -21,7 +21,7 @@ type request struct {
 	Method string
 	URL    *url.URL
 	Header http.Header
-	Body   string
+	Body   []byte
 }
 
 // response is a recorded HTTP response.
@@ -33,7 +33,7 @@ type response struct {
 	ProtoMinor int
 
 	Header           http.Header
-	Body             string
+	Body             []byte
 	ContentLength    int64
 	TransferEncoding []string
 	Trailer          http.Header

--- a/examples/example5.go
+++ b/examples/example5.go
@@ -27,7 +27,7 @@ func Example5() {
 				// ignore the X-Transaction-Id since it changes per-request
 				return strings.ToLower(key) == "x-transaction-id"
 			},
-			ResponseFilterFunc: func(respHeader http.Header, respBody string, reqHeader http.Header) (*http.Header, *string) {
+			ResponseFilterFunc: func(respHeader http.Header, respBody []byte, reqHeader http.Header) (*http.Header, *[]byte) {
 				// overwrite X-Transaction-Id in the Response with that from the Request
 				respHeader.Set("X-Transaction-Id", reqHeader.Get("X-Transaction-Id"))
 

--- a/govcr_example3_test.go
+++ b/govcr_example3_test.go
@@ -66,6 +66,6 @@ func Example_number3HeaderExclusionVCR() {
 	runTestEx4()
 
 	// Output:
-	// 404 text/html true 404 text/html true 405  true 405  true {TracksLoaded:0 TracksRecorded:4 TracksPlayed:0}
-	// 404 text/html true 404 text/html true 405  true 405  true {TracksLoaded:4 TracksRecorded:0 TracksPlayed:4}
+	// 404 text/html true 404 text/html true 404 text/html true 404 text/html true {TracksLoaded:0 TracksRecorded:4 TracksPlayed:0}
+	// 404 text/html true 404 text/html true 404 text/html true 404 text/html true {TracksLoaded:4 TracksRecorded:0 TracksPlayed:4}
 }


### PR DESCRIPTION
The conversion of a `[]byte` to a `string` can (and does) fail if the byte content is not valid unicode. To avoid this, pass around the `[]byte`. Allows binary body payloads to function correctly.