### PR TITLE
Add Long Play (compression) to cassettes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ When  multiple matching **tracks** exist for the same request on the **cassette*
 
 When the last request matching **track** has been replayed, **govcr** cycles back to the first **track** again and so on.
 
-**Cassette** recordings are saved under `./govcr-fixtures` (by default) as `*.cassette` files in JSON format.
+**Cassette** recordings are saved under `./govcr-fixtures` (by default) as `*.cassette` files in JSON format. 
+
+You can enable **LongPlay** mode that will compress the cassette content. This is enabled by using the `VCRConfig.LongPlay`.  When enabling it you must re-record your content. The compression used is standard gzip.
 
 ### VCRConfig
 
@@ -108,7 +110,7 @@ This simply redirects all **govcr** logging to the OS's standard Null device (e.
 
 - http / https supported and any other protocol implemented by the supplied `http.Client`'s `http.RoundTripper`.
 
-- Hook to define HTTP headers that should be ignored from the HTTP request when attemtping to retrieve a **track** for playback.
+- Hook to define HTTP headers that should be ignored from the HTTP request when attempting to retrieve a **track** for playback.
   This is useful to deal with non-static HTTP headers (for example, containing a timestamp).
 
 - Hook to transform the Header / Body of an HTTP request to deal with non-static data. The purpose is similar to the hook for headers described above but with the ability to modify the data.

--- a/govcr.go
+++ b/govcr.go
@@ -34,6 +34,8 @@ type VCRConfig struct {
 	// Filter to run before a response is returned.
 	ResponseFilters ResponseFilters
 
+	// LongPlay will compress data on cassettes.
+	LongPlay         bool
 	DisableRecording bool
 	Logging          bool
 	CassettePath     string
@@ -164,7 +166,7 @@ func NewVCR(cassetteName string, vcrConfig *VCRConfig) *VCRControlPanel {
 	}
 
 	// load cassette
-	cassette, err := loadCassette(cassetteName, vcrConfig.CassettePath)
+	cassette, err := loadCassette(cassetteName, vcrConfig.CassettePath, vcrConfig.LongPlay)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/govcr_test.go
+++ b/govcr_test.go
@@ -13,11 +13,6 @@ import (
 	"github.com/seborama/govcr"
 )
 
-const (
-	wipeCassette = true
-	keepCassette = false
-)
-
 func TestPlaybackOrder(t *testing.T) {
 	cassetteName := "TestPlaybackOrder"
 	clientNum := 1
@@ -34,7 +29,7 @@ func TestPlaybackOrder(t *testing.T) {
 		t.Fatalf("err from govcr.DeleteCassette(): Expected nil, got %s", err)
 	}
 
-	vcr := createVCR(cassetteName, wipeCassette)
+	vcr := createVCR(cassetteName, false)
 	client := vcr.Client
 
 	// run requests
@@ -45,7 +40,7 @@ func TestPlaybackOrder(t *testing.T) {
 		expectedBody := fmt.Sprintf("Hello, client %d", i)
 		checkResponseForTestPlaybackOrder(t, resp, expectedBody)
 
-		if !govcr.CassetteExistsAndValid(cassetteName, "") {
+		if !govcr.CassetteExistsAndValid(cassetteName, "", false) {
 			t.Fatalf("CassetteExists: expected true, got false")
 		}
 
@@ -56,7 +51,7 @@ func TestPlaybackOrder(t *testing.T) {
 	clientNum = 1
 
 	// re-run request and expect play back from vcr
-	vcr = createVCR(cassetteName, keepCassette)
+	vcr = createVCR(cassetteName, false)
 	client = vcr.Client
 
 	// run requests
@@ -67,7 +62,7 @@ func TestPlaybackOrder(t *testing.T) {
 		expectedBody := fmt.Sprintf("Hello, client %d", i)
 		checkResponseForTestPlaybackOrder(t, resp, expectedBody)
 
-		if !govcr.CassetteExistsAndValid(cassetteName, "") {
+		if !govcr.CassetteExistsAndValid(cassetteName, "", false) {
 			t.Fatalf("CassetteExists: expected true, got false")
 		}
 
@@ -98,7 +93,7 @@ func TestNonUtf8EncodableBinaryBody(t *testing.T) {
 		t.Fatalf("err from govcr.DeleteCassette(): Expected nil, got %s", err)
 	}
 
-	vcr := createVCR(cassetteName, wipeCassette)
+	vcr := createVCR(cassetteName, false)
 	client := vcr.Client
 
 	// run requests
@@ -109,7 +104,7 @@ func TestNonUtf8EncodableBinaryBody(t *testing.T) {
 		expectedBody := generateBinaryBody(i)
 		checkResponseForTestPlaybackOrder(t, resp, expectedBody)
 
-		if !govcr.CassetteExistsAndValid(cassetteName, "") {
+		if !govcr.CassetteExistsAndValid(cassetteName, "", false) {
 			t.Fatalf("CassetteExists: expected true, got false")
 		}
 
@@ -120,7 +115,7 @@ func TestNonUtf8EncodableBinaryBody(t *testing.T) {
 	clientNum = 1
 
 	// re-run request and expect play back from vcr
-	vcr = createVCR(cassetteName, keepCassette)
+	vcr = createVCR(cassetteName, false)
 	client = vcr.Client
 
 	// run requests
@@ -131,7 +126,7 @@ func TestNonUtf8EncodableBinaryBody(t *testing.T) {
 		expectedBody := generateBinaryBody(i)
 		checkResponseForTestPlaybackOrder(t, resp, expectedBody)
 
-		if !govcr.CassetteExistsAndValid(cassetteName, "") {
+		if !govcr.CassetteExistsAndValid(cassetteName, "", false) {
 			t.Fatalf("CassetteExists: expected true, got false")
 		}
 
@@ -139,7 +134,42 @@ func TestNonUtf8EncodableBinaryBody(t *testing.T) {
 	}
 }
 
-func createVCR(cassetteName string, wipeCassette bool) *govcr.VCRControlPanel {
+func TestLongPlay(t *testing.T) {
+	cassetteName := t.Name()
+	clientNum := 1
+
+	// create a test server
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello, client %d", clientNum)
+		clientNum++
+	}))
+
+	fmt.Println("Phase 1 ================================================")
+
+	if err := govcr.DeleteCassette(cassetteName, ""); err != nil {
+		t.Fatalf("err from govcr.DeleteCassette(): Expected nil, got %s", err)
+	}
+
+	vcr := createVCR(cassetteName, true)
+	client := vcr.Client
+
+	// run requests
+	for i := 1; i <= 10; i++ {
+		resp, _ := client.Get(ts.URL)
+
+		// check outcome of the request
+		expectedBody := fmt.Sprintf("Hello, client %d", i)
+		checkResponseForTestPlaybackOrder(t, resp, expectedBody)
+
+		if !govcr.CassetteExistsAndValid(cassetteName, "", true) {
+			t.Fatalf("CassetteExists: expected true, got false")
+		}
+
+		checkStats(t, vcr.Stats(), 0, i, 0)
+	}
+}
+
+func createVCR(cassetteName string, lp bool) *govcr.VCRControlPanel {
 	// create a custom http.Transport.
 	tr := http.DefaultTransport.(*http.Transport)
 	tr.TLSClientConfig = &tls.Config{
@@ -149,7 +179,8 @@ func createVCR(cassetteName string, wipeCassette bool) *govcr.VCRControlPanel {
 	// create a vcr
 	return govcr.NewVCR(cassetteName,
 		&govcr.VCRConfig{
-			Client: &http.Client{Transport: tr},
+			Client:   &http.Client{Transport: tr},
+			LongPlay: lp,
 		})
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -99,7 +99,7 @@ func TestRequestExcludeHeaderFunc(t *testing.T) {
 	header1, header2 := textproto.CanonicalMIMEHeaderKey("a-header"), textproto.CanonicalMIMEHeaderKey("another-header")
 
 	// We expect both headers to be checked.
-	want := map[string]struct{}{header1:{}, header2: {}}
+	want := map[string]struct{}{header1: {}, header2: {}}
 	r := RequestExcludeHeaderFunc(func(key string) bool {
 		_, ok := want[key]
 		if !ok {


### PR DESCRIPTION
To play back a cassette with "long play" it must have been recorded with it.

In the test example it reduces the size from 76k to a little over 2k.

In the test setup I removed `wipeCassette bool` parameter since it wasn't used.