### PR TITLE
Add option to remove TLS from recording

### DIFF
--- a/cassette.go
+++ b/cassette.go
@@ -215,7 +215,8 @@ type cassette struct {
 	Tracks     []track
 
 	// stats is not exported since it doesn't need serialising
-	stats Stats
+	stats     Stats
+	removeTLS bool
 }
 
 func (k7 *cassette) isLongPlay() bool {
@@ -285,6 +286,9 @@ func (k7 *cassette) gunzipFilter(data []byte) ([]byte, error) {
 
 // addTrack adds a track to a cassette.
 func (k7 *cassette) addTrack(track *track) {
+	if k7.removeTLS {
+		track.Response.TLS = nil
+	}
 	k7.Tracks = append(k7.Tracks, *track)
 }
 

--- a/cassette_test.go
+++ b/cassette_test.go
@@ -2,6 +2,7 @@ package govcr
 
 import (
 	"bytes"
+	"crypto/tls"
 	"reflect"
 	"strings"
 	"testing"
@@ -198,6 +199,90 @@ func Test_cassetteNameToFilename(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := cassetteNameToFilename(tt.args.cassetteName, tt.args.cassettePath); !strings.HasSuffix(got, tt.want) {
 				t.Errorf("cassetteNameToFilename() = %v, want suffix %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_cassette_addTrack(t *testing.T) {
+	type fields struct {
+		removeTLS bool
+	}
+	type args struct {
+		track track
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name: "with tls, keep",
+			fields: fields{
+				removeTLS: false,
+			},
+			args: args{
+				track: track{
+					Response: response{
+						TLS: &tls.ConnectionState{},
+					},
+				},
+			},
+		},
+		{
+			name: "with tls, remove",
+			fields: fields{
+				removeTLS: true,
+			},
+			args: args{
+				track: track{
+					Response: response{
+						TLS: &tls.ConnectionState{},
+					},
+				},
+			},
+		},
+		{
+			name: "without tls, keep",
+			fields: fields{
+				removeTLS: false,
+			},
+			args: args{
+				track: track{
+					Response: response{
+						TLS: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "without tls, remove",
+			fields: fields{
+				removeTLS: true,
+			},
+			args: args{
+				track: track{
+					Response: response{
+						TLS: nil,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k7 := &cassette{
+				Name:      tt.name,
+				Path:      tt.name,
+				removeTLS: tt.fields.removeTLS,
+			}
+			k7.addTrack(&tt.args.track)
+			gotTLS := k7.Tracks[0].Response.TLS != nil
+			if gotTLS && tt.fields.removeTLS {
+				t.Errorf("got TLS, but it should have been removed")
+			}
+			if !gotTLS && !tt.fields.removeTLS && tt.args.track.Response.TLS != nil {
+				t.Errorf("tls was removed, but shouldn't")
 			}
 		})
 	}

--- a/govcr.go
+++ b/govcr.go
@@ -39,6 +39,10 @@ type VCRConfig struct {
 	DisableRecording bool
 	Logging          bool
 	CassettePath     string
+
+	// RemoveTLS will remove TLS from the Response when recording.
+	// TLS information is rarely needed and takes up a lot of space.
+	RemoveTLS bool
 }
 
 // PCB stands for Printed Circuit Board. It is a structure that holds some
@@ -170,6 +174,7 @@ func NewVCR(cassetteName string, vcrConfig *VCRConfig) *VCRControlPanel {
 	if err != nil {
 		logger.Fatal(err)
 	}
+	cassette.removeTLS = vcrConfig.RemoveTLS
 
 	// create PCB
 	pcbr := &pcb{


### PR DESCRIPTION
TLS is often not needed for responses and take up a lot of space.

Add `RemoveTLS` option to `VCRConfig` struct. Default value `false` keeps existing behaviour.