### PR TITLE
WIP - TrackFilters

### DIFF
--- a/pcb.go
+++ b/pcb.go
@@ -12,6 +12,7 @@ type pcb struct {
 	Transport        http.RoundTripper
 	RequestFilter    RequestFilter
 	ResponseFilter   ResponseFilter
+	TrackFilter      TrackFilter
 	Logger           *log.Logger
 	DisableRecording bool
 	CassettePath     string


### PR DESCRIPTION
TrackFilters allow modifying what is stored in tracks.
An example use case is filtering Authorization headers, cookies and request/response bodies.

Possible solution for #42, requesting feedback before I continue.
Example use cases:
```go
func TestClientWrapper(c *http.Client, cassetteName string) *http.Client {
	cfg := govcr.VCRConfig{
		CassettePath:     "./testdata/govcr-fixtures",
		Client:           c,
		RemoveTLS:        true,
		Logging:          testing.Verbose(),
		DisableRecording: !IsDevMode(),
	}

	cfg.TrackFilters.Add(
		govcr.TrackRequestDeleteHeaderKeys("Authorization"),
		govcr.TrackResponseDeleteHeaderKeys("Set-Cookie"),
		govcr.TrackFilter(func(req *http.Request, resp *http.Response, err error) (*http.Request, *http.Response) {
			req.URL.Host = "mock.okta.example.com"
			return req, resp
		}),

		govcr.TrackRequestChangeBody(func(b []byte) []byte {
			client := CreateClientOptions{}
			if err := json.Unmarshal(b, &client); err != nil {
				log.Fatal(err)
			}
			client.ClientName = "vault-client-MOCK-3e9c0c50-6b3b-9335-87c3-9055e07019aa"
			b, err := json.Marshal(&client)
			if err != nil {
				log.Fatal(err)
			}

			return b
		}).OnMethod(http.MethodPost).OnPath("/oauth2/v1/clients/?$"),
		govcr.TrackResponseChangeBody(func(b []byte) []byte {
			client := ClientResponse{}
			if err := json.Unmarshal(b, &client); err != nil {
				log.Fatal(err)
			}
			client.ClientID = "0oaftpbw8rpuExJeA356"
			client.ClientSecret = "MOCK-CLIENT-SECRET"
			client.ClientName = "vault-client-MOCK-3e9c0c50-6b3b-9335-87c3-9055e07019aa"
			client.ClientIDIssuedAt = 1554750248
			b, err := json.Marshal(&client)
			if err != nil {
				log.Fatal(err)
			}

			return b
		}).OnMethod(http.MethodPost).OnPath("/oauth2/v1/clients/?$").OnStatus(http.StatusCreated),

		govcr.TrackFilter(func(req *http.Request, resp *http.Response, err error) (*http.Request, *http.Response) {
			req.URL.Path = "/oauth2/v1/clients/0oaftpbw8rpuExJeA356/lifecycle/newSecret"
			return req, resp
		}).OnMethod(http.MethodPost).OnPath("/oauth2/v1/clients/[^/]+/lifecycle/newSecret"),
		govcr.TrackResponseChangeBody(func(b []byte) []byte {
			client := ClientResponse{}
			if err := json.Unmarshal(b, &client); err != nil {
				log.Fatal(err)
			}
			client.ClientID = "0oaftpbw8rpuExJeA356"
			client.ClientSecret = "MOCK-CLIENT-NEW-SECRET"
			client.ClientName = "vault-client-MOCK-3e9c0c50-6b3b-9335-87c3-9055e07019aa"
			client.ClientIDIssuedAt = 1554750248
			b, err := json.Marshal(&client)
			if err != nil {
				log.Fatal(err)
			}

			return b
		}).OnMethod(http.MethodPost).OnPath("/oauth2/v1/clients/[^/]+/lifecycle/newSecret").OnStatus(http.StatusOK),

		govcr.TrackRequestChangeBody(func(b []byte) []byte {
			client := CreateClientOptions{}
			if err := json.Unmarshal(b, &client); err != nil {
				log.Fatal(err)
			}
			client.ClientName = "vault-client-MOCK-3e9c0c50-6b3b-9335-87c3-9055e07019aa-updated"
			b, err := json.Marshal(&client)
			if err != nil {
				log.Fatal(err)
			}

			return b
		}).OnMethod(http.MethodPut).OnPath("/oauth2/v1/clients/.+"),
		govcr.TrackFilter(func(req *http.Request, resp *http.Response, err error) (*http.Request, *http.Response) {
			req.URL.Path = "/oauth2/v1/clients/nonexistent-MOCK-f69b6323-bb5d-0caf-682b-600f23750e66"
			return req, resp
		}).OnMethod(http.MethodPut).OnPath("/oauth2/v1/clients/nonexistent-.*"),

		govcr.TrackFilter(func(req *http.Request, resp *http.Response, err error) (*http.Request, *http.Response) {
			req.URL.Path = "/oauth2/v1/clients/0oaftpbw8rpuExJeA356"
			return req, resp
		}).OnMethod(http.MethodPut).OnPath("/oauth2/v1/clients/[^n].*"),

		govcr.TrackFilter(func(req *http.Request, resp *http.Response, err error) (*http.Request, *http.Response) {
			req.URL.Path = "/oauth2/v1/clients/0oaftpbw8rpuExJeA356"
			return req, resp
		}).OnMethod(http.MethodDelete).OnPath("/oauth2/v1/clients/.+"),
	)
	vcr := govcr.NewVCR(cassetteName, &cfg)
	return vcr.Client
}
```