### PR TITLE
Add ability to remove sensitive information from responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ Refer to [examples/example6.go](examples/example6.go) for advanced examples.
 
 `ResponseFilters` is the flip side of `RequestFilters`. It receives the **response** Header / Body to allow their transformation. Unlike `RequestFilters`, this influences the response returned from the request to the client. The request header is also passed to `ResponseFilter` but read-only and solely for the purpose of extracting request data for situations where it is needed to transform the Response (such as to retrieve an identifier that must be the same in the request and the response).
 
+### Runtime transforming of the response before saving.
+
+`SaveFilters` receives the **response** Header / Body to allow their transformation even before they are saved. 
+This will allow you to filter out sensitive information returned and not have it stored.
+Otherwise they behave the same as `ResponseFilters`.
+
 ## Examples
 
 ### Example 1 - Simple VCR

--- a/cassette_test.go
+++ b/cassette_test.go
@@ -2,7 +2,6 @@ package govcr
 
 import (
 	"bytes"
-	"crypto/tls"
 	"net/http"
 	"reflect"
 	"strings"
@@ -208,88 +207,6 @@ func Test_cassetteNameToFilename(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := cassetteNameToFilename(tt.args.cassetteName, tt.args.cassettePath); !strings.HasSuffix(got, tt.want) {
 				t.Errorf("cassetteNameToFilename() = %v, want suffix %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_cassette_addTrack(t *testing.T) {
-	type fields struct {
-		removeTLS bool
-	}
-	type args struct {
-		track track
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-	}{
-		{
-			name: "with tls, keep",
-			fields: fields{
-				removeTLS: false,
-			},
-			args: args{
-				track: track{
-					Response: response{
-						TLS: &tls.ConnectionState{},
-					},
-				},
-			},
-		},
-		{
-			name: "with tls, remove",
-			fields: fields{
-				removeTLS: true,
-			},
-			args: args{
-				track: track{
-					Response: response{
-						TLS: &tls.ConnectionState{},
-					},
-				},
-			},
-		},
-		{
-			name: "without tls, keep",
-			fields: fields{
-				removeTLS: false,
-			},
-			args: args{
-				track: track{
-					Response: response{
-						TLS: nil,
-					},
-				},
-			},
-		},
-		{
-			name: "without tls, remove",
-			fields: fields{
-				removeTLS: true,
-			},
-			args: args{
-				track: track{
-					Response: response{
-						TLS: nil,
-					},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			k7 := newCassette(tt.name, tt.name)
-			k7.removeTLS = tt.fields.removeTLS
-
-			k7.addTrack(&tt.args.track)
-			gotTLS := k7.Tracks[0].Response.TLS != nil
-			if gotTLS && tt.fields.removeTLS {
-				t.Errorf("got TLS, but it should have been removed")
-			}
-			if !gotTLS && !tt.fields.removeTLS && tt.args.track.Response.TLS != nil {
-				t.Errorf("tls was removed, but shouldn't")
 			}
 		})
 	}

--- a/examples/example7.go
+++ b/examples/example7.go
@@ -93,6 +93,11 @@ func Example7() {
 		}).OnStatus(200),
 	)
 
+	// Remove TLS from saved data
+	cfg.SaveFilters.Add(govcr.ResponseSetTLS(nil))
+	// Remove a secret from the response.
+	cfg.SaveFilters.Add(govcr.ResponseDeleteHeaderKeys("Response-Secret"))
+
 	orderID := fmt.Sprint(rand.Int63())
 	vcr := govcr.NewVCR(example7CassetteName, &cfg)
 

--- a/govcr_example7_test.go
+++ b/govcr_example7_test.go
@@ -93,6 +93,11 @@ func runTestEx7(rng *rand.Rand) {
 		}).OnStatus(200),
 	)
 
+	// Remove TLS from saved data
+	cfg.SaveFilters.Add(govcr.ResponseSetTLS(nil), )
+	// Remove a secret from the response.
+	cfg.SaveFilters.Add(govcr.ResponseDeleteHeaderKeys("Response-Secret"))
+	
 	orderID := fmt.Sprint(rng.Uint64())
 	vcr := govcr.NewVCR(example7CassetteName, &cfg)
 

--- a/response.go
+++ b/response.go
@@ -50,7 +50,7 @@ func (r Response) apply(resp *http.Response) *http.Response {
 	return resp
 }
 
-// apply the response to an http response.
+// apply the response to an internal response.
 func (r Response) applyRecorded(resp response) response {
 	resp.Header = r.Header
 	resp.Body = r.Body

--- a/vcr_transport_test.go
+++ b/vcr_transport_test.go
@@ -1,6 +1,7 @@
 package govcr
 
 import (
+	"crypto/tls"
 	"log"
 	"net/http"
 	"os"
@@ -8,12 +9,19 @@ import (
 	"testing"
 )
 
-type mockRoundTripper struct{}
+type mockRoundTripper struct {
+	addTLS bool
+}
 
 func (t *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	tls := &tls.ConnectionState{}
+	if !t.addTLS {
+		tls = nil
+	}
 	return &http.Response{
 		Request:    req,
 		StatusCode: http.StatusMovedPermanently,
+		TLS:        tls,
 	}, nil
 }
 
@@ -42,13 +50,14 @@ func Test_vcrTransport_RoundTrip_doesNotChangeLiveReqOrLiveResp(t *testing.T) {
 	responseFilters := ResponseFilters{}
 	responseFilters.Add(mutateResp)
 
-	mrt := &mockRoundTripper{}
+	mrt := &mockRoundTripper{addTLS: true}
 	transport := &vcrTransport{
 		PCB: &pcb{
 			DisableRecording: true,
 			Transport:        mrt,
 			RequestFilter:    requestFilters.combined(),
 			ResponseFilter:   responseFilters.combined(),
+			SaveFilter:       ResponseSetTLS(nil),
 			Logger:           logger,
 			CassettePath:     "",
 		},
@@ -75,13 +84,132 @@ func Test_vcrTransport_RoundTrip_doesNotChangeLiveReqOrLiveResp(t *testing.T) {
 	wantResp := http.Response{
 		Request:    wantReq,
 		StatusCode: http.StatusMovedPermanently,
+		TLS:        nil,
+		Status:     http.StatusText(http.StatusMovedPermanently),
 	}
 
 	if !reflect.DeepEqual(req, wantReq) {
 		t.Errorf("vcrTransport.RoundTrip() Request has been modified = %+v, want %+v", req, wantReq)
 	}
 
+	if r1, r2 := *gotResp.Request, *wantResp.Request; !reflect.DeepEqual(r1, r2) {
+		t.Errorf("vcrTransport.RoundTrip() Response request has been modified = %+v, want %+v", r1, r2)
+	}
+
+	// These are compared above.
+	gotResp.Request, wantResp.Request = nil, nil
 	if !reflect.DeepEqual(gotResp, &wantResp) {
 		t.Errorf("vcrTransport.RoundTrip() Response has been modified = %+v, want %+v", gotResp, wantResp)
+	}
+}
+
+func Test_vcrTransport_RemoveTLS(t *testing.T) {
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	type fields struct {
+		removeTLS bool
+	}
+	type args struct {
+		track track
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name: "with tls, keep",
+			fields: fields{
+				removeTLS: false,
+			},
+			args: args{
+				track: track{
+					Response: response{
+						TLS: &tls.ConnectionState{},
+					},
+				},
+			},
+		},
+		{
+			name: "with tls, remove",
+			fields: fields{
+				removeTLS: true,
+			},
+			args: args{
+				track: track{
+					Response: response{
+						TLS: &tls.ConnectionState{},
+					},
+				},
+			},
+		},
+		{
+			name: "without tls, keep",
+			fields: fields{
+				removeTLS: false,
+			},
+			args: args{
+				track: track{
+					Response: response{
+						TLS: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "without tls, remove",
+			fields: fields{
+				removeTLS: true,
+			},
+			args: args{
+				track: track{
+					Response: response{
+						TLS: nil,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			saveFilters := ResponseFilters{}
+			if tt.fields.removeTLS {
+				saveFilters.Add(ResponseSetTLS(nil))
+			}
+
+			mrt := &mockRoundTripper{addTLS: tt.args.track.Response.TLS != nil}
+			transport := &vcrTransport{
+				PCB: &pcb{
+					DisableRecording: false,
+					Transport:        mrt,
+					RequestFilter:    nil,
+					ResponseFilter:   nil,
+					Logger:           logger,
+					SaveFilter:       saveFilters.combined(),
+					CassettePath:     "",
+				},
+				Cassette: newCassette("", ""),
+			}
+
+			req, err := http.NewRequest("GET", "https://example.com/path?query", toReadCloser([]byte("Lorem ipsum dolor sit amet")))
+			if err != nil {
+				t.Errorf("req http.NewRequest() error = %v", err)
+				return
+			}
+
+			_, err = transport.RoundTrip(req)
+			if err != nil {
+				t.Errorf("vcrTransport.RoundTrip() error = %v", err)
+				return
+			}
+
+			gotTLS := transport.Cassette.Tracks[0].Response.TLS != nil
+			if gotTLS && tt.fields.removeTLS {
+				t.Errorf("got TLS, but it should have been removed")
+			}
+			if !gotTLS && !tt.fields.removeTLS && tt.args.track.Response.TLS != nil {
+				t.Errorf("tls was removed, but shouldn't")
+			}
+		})
 	}
 }


### PR DESCRIPTION
This will allow filtering of responses before they are saved.

We also allow for updates to Trailer, TLS and ContentLength.

Small refactor to move the filtering upstream from the cassette (as requested in the code comment)

Please, ensure your pull request meet these guidelines:

Fixes #42 

- [x] My code is written in TDD (test driven development) fashion.
- [x] My code adheres to Go standards
      I have run `make lint`,
      or I have used https://goreportcard.com/
      and I have taken the necessary compliance actions.
- [x] I have provided / updated examples.
- [x] I have updated [README.md].

Thanks for your PR, you're awesome! :+1:
