### PR TITLE
Skip Saving tracks on Error Responses ( 404, 402, etc.. )

### DIFF
--- a/examples/example8.go
+++ b/examples/example8.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/seborama/govcr"
+)
+
+const example8CassetteName = "MyCassette8"
+
+// Example8 is an example use of SkipErrorCodes feature.
+func Example1() {
+	cfg := govcr.VCRConfig{
+		Logging: true,
+		SkipErrorCodes: true,
+	}
+	vcr := govcr.NewVCR(example1CassetteName, &cfg)
+	vcr.Client.Get("http://www.example.com/foo")
+	fmt.Printf("%+v\n", vcr.Stats())
+}

--- a/examples/example8.go
+++ b/examples/example8.go
@@ -9,7 +9,7 @@ import (
 const example8CassetteName = "MyCassette8"
 
 // Example8 is an example use of SkipErrorCodes feature.
-func Example1() {
+func Example8() {
 	cfg := govcr.VCRConfig{
 		Logging: true,
 		SkipErrorCodes: true,

--- a/govcr.go
+++ b/govcr.go
@@ -44,6 +44,10 @@ type VCRConfig struct {
 	// RemoveTLS will remove TLS from the Response when recording.
 	// TLS information is rarely needed and takes up a lot of space.
 	RemoveTLS bool
+
+	// SkipErrorCodes will skip saving any request-resposne pair whose response status code was either one of the following:
+	// ( 400,401,403,404,500)
+	SkipErrorCodes bool
 }
 
 // NewVCR creates a new VCR and loads a cassette.
@@ -87,6 +91,7 @@ func NewVCR(cassetteName string, vcrConfig *VCRConfig) *VCRControlPanel {
 		ResponseFilter:   vcrConfig.ResponseFilters.combined(),
 		Logger:           logger,
 		CassettePath:     vcrConfig.CassettePath,
+		SkipErrorCodes:   vcrConfig.SkipErrorCodes,
 	}
 
 	// create VCR's HTTP client

--- a/govcr_example8_test.go
+++ b/govcr_example8_test.go
@@ -1,0 +1,45 @@
+package govcr_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/seborama/govcr"
+)
+
+const example8CassetteName = "MyCassette8"
+
+func runTestEx8() {
+	// Create vcr and make http call
+
+	cfg := govcr.VCRConfig{
+		Logging: true,
+		SkipErrorCodes: true,
+	}
+	
+	vcr := govcr.NewVCR(example8CassetteName, &cfg)
+	resp, _ := vcr.Client.Get("http://www.example.com/foo")
+
+	// Show results
+	fmt.Printf("%d ", resp.StatusCode)
+	fmt.Printf("%s ", resp.Header.Get("Content-Type"))
+	fmt.Printf("%+v\n", vcr.Stats())
+}
+
+// Example_number8SkipErrorCodes is an example of the use of the SkipErrorCodes functionality.
+// It shows how to use govcr by adding SkipErrorCodes to skip saving tracks if an error is returned ( status code: 404, 403 etc.. )
+
+func Example_number8SkipErrorCodes() {
+	// Delete cassette to enable live HTTP call
+	govcr.DeleteCassette(example8CassetteName, "")
+
+	// 1st run of the test - will use live HTTP call - Will not save the track due to 404.
+	runTestEx8()
+	// 2nd run of the test - will use live HTTP call as well - Will not save the track again due to 404.
+	runTestEx8()
+
+	// Output:
+	// 404 text/html; charset=UTF-8 true {TracksLoaded:0 TracksRecorded:0 TracksPlayed:0}
+	// 404 text/html; charset=UTF-8 true {TracksLoaded:0 TracksRecorded:0 TracksPlayed:0}
+}

--- a/pcb.go
+++ b/pcb.go
@@ -15,6 +15,7 @@ type pcb struct {
 	Logger           *log.Logger
 	DisableRecording bool
 	CassettePath     string
+	SkipErrorCodes   bool
 }
 
 const trackNotFound = -1


### PR DESCRIPTION
### Feature Details:
Allow to skip saving tracks where API call returns an error response such as 404 etc..

Please, ensure your pull request meet these guidelines:
- [✔️] My code is written in TDD (test driven development) fashion.
- [✔️] My code adheres to Go standards
      I have run `make lint`,
      or I have used https://goreportcard.com/
      and I have taken the necessary compliance actions.
- [✔️] I have provided / updated examples.

Thanks for your PR, you're awesome! :+1:
