### PR TITLE
Ensure RequestMatcher cannot mutate the request or the response

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,26 +180,34 @@ func TestExample2() {
 }
 ```
 
-### Recipe: Remove Response TLS from cassette or from track playback
+### Recipe: Remove Response TLS
 
 Use the provided mutator `track.ResponseDeleteTLS`.
 
-Remove Response.TLS from the cassette recording:
+Remove Response.TLS from the cassette **recording**:
 
 ```go
 	vcr := govcr.NewVCR(
 		govcr.WithCassette(exampleCassetteName2),
-		govcr.WithTrackRecordingMutators(track.ResponseDeleteTLS),
+		govcr.WithTrackRecordingMutators(track.ResponseDeleteTLS()),
+        //             ^^^^^^^^^
 	)
+    // or, similarly:
+    vcr.AddRecordingMutators(track.ResponseDeleteTLS())
+    //     ^^^^^^^^^
 ```
 
-Remove Response.TLS from the track at playback time:
+Remove Response.TLS from the track at **playback** time:
 
 ```go
 	vcr := govcr.NewVCR(
 		govcr.WithCassette(exampleCassetteName2),
-		govcr.WithTrackReplayingMutators(track.ResponseDeleteTLS),
+		govcr.WithTrackReplayingMutators(track.ResponseDeleteTLS()),
+        //             ^^^^^^^^^
 	)
+    // or, similarly:
+    vcr.AddReplayingMutators(track.ResponseDeleteTLS())
+    //     ^^^^^^^^^
 ```
 
 ### Recipe: Change the playback mode of the VCR

--- a/cassette/cassette.go
+++ b/cassette/cassette.go
@@ -45,7 +45,7 @@ func NewCassette(name string, options ...Options) *Cassette {
 // Stats returns the cassette's Stats.
 func (k7 *Cassette) Stats() *stats.Stats {
 	if k7 == nil {
-		return nil
+		return &stats.Stats{}
 	}
 
 	s := stats.Stats{
@@ -59,6 +59,10 @@ func (k7 *Cassette) Stats() *stats.Stats {
 }
 
 func (k7 *Cassette) tracksPlayed() int32 {
+	if k7 == nil {
+		return 0
+	}
+
 	replayed := int32(0)
 
 	k7.trackSliceMutex.RLock()
@@ -88,7 +92,7 @@ func (k7 *Cassette) NumberOfTracks() int32 {
 // ReplayTrack returns the specified track number, as recorded on cassette.
 func (k7 *Cassette) ReplayTrack(trackNumber int32) (*track.Track, error) {
 	if trackNumber >= k7.NumberOfTracks() {
-		//nolint: err113
+		//nolint: goerr113
 		return nil, fmt.Errorf("invalid track number %d (only %d available) (track #0 stands for first track)", trackNumber, k7.NumberOfTracks())
 	}
 

--- a/cassette/cassette_wb_test.go
+++ b/cassette/cassette_wb_test.go
@@ -13,11 +13,19 @@ func Test_cassette_NumberOfTracks_ZeroWhenNoCassette(t *testing.T) {
 	assert.Zero(t, unit.NumberOfTracks())
 }
 
-func Test_cassette_Stats_NilWhenNoCassette(t *testing.T) {
+func Test_cassette_Stats_ZeroWhenNoCassette(t *testing.T) {
 	var unit *Cassette
 
 	got := unit.Stats()
-	assert.Nil(t, got)
+
+	expected := &stats.Stats{
+		TotalTracks:    0,
+		TracksLoaded:   0,
+		TracksRecorded: 0,
+		TracksPlayed:   0,
+	}
+
+	assert.Equal(t, got, expected)
 }
 
 func Test_cassette_Stats_ZeroWhenEmptyCassette(t *testing.T) {

--- a/cassette/track/errors/errors.go
+++ b/cassette/track/errors/errors.go
@@ -1,0 +1,23 @@
+package trkerr
+
+import (
+	"fmt"
+)
+
+// ErrTransportFailure is an error that indicates a transport failure during the HTTP dialogue.
+type ErrTransportFailure struct {
+	errType string
+	errMsg  string
+}
+
+// NewErrTransportFailure creates a new initialised ErrTransportFailure.
+func NewErrTransportFailure(errType, errMsg string) *ErrTransportFailure {
+	return &ErrTransportFailure{
+		errType: errType,
+		errMsg:  errMsg,
+	}
+}
+
+func (e ErrTransportFailure) Error() string {
+	return fmt.Sprintf(e.errType + ": " + e.errMsg)
+}

--- a/cassette/track/track.go
+++ b/cassette/track/track.go
@@ -2,11 +2,14 @@ package track
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
+
+	"github.com/pkg/errors"
+
+	trkerr "github.com/seborama/govcr/v6/cassette/track/errors"
 )
 
 // Track is a recording (HTTP Request + Response) in a cassette.
@@ -51,17 +54,6 @@ func NewTrack(req *Request, resp *Response, reqErr error) *Track {
 	return track
 }
 
-// GetRequest returns the HTTP Request object of this track.
-func (trk *Track) GetRequest() *Request {
-	return &trk.Request
-}
-
-// GetResponse returns the HTTP Response object of this track.
-// Note: by convention, when an HTTP error occurred, the Response should be nil.
-func (trk *Track) GetResponse() *Response {
-	return trk.Response
-}
-
 // IsReplayed returns true if the Track has already been replayed, otherwise
 // it returns false.
 func (trk *Track) IsReplayed() bool {
@@ -92,13 +84,11 @@ func (trk *Track) ToErr() error {
 			Net:    "govcr",
 			Source: nil,
 			Addr:   nil,
-			//nolint: err113
-			Err: errors.New(errType + ": " + errMsg),
+			Err:    errors.WithStack(trkerr.NewErrTransportFailure(errType, errMsg)),
 		}
 	}
 
-	//nolint: err113
-	return errors.New(errType + ": " + errMsg)
+	return errors.WithStack(trkerr.NewErrTransportFailure(errType, errMsg))
 }
 
 // toHTTPRequest converts the track Request to an http.Request.

--- a/govcr_wb_test.go
+++ b/govcr_wb_test.go
@@ -152,7 +152,16 @@ func (suite *GoVCRWBTestSuite) TestRoundTrip_DoesNotChangeLiveRequestOrResponse(
 			trk.ErrType = func(s string) *string { return &s }("err type")
 		})
 
-	suite.vcr.SetRequestMatcher(NewBlankRequestMatcher())
+	suite.vcr.SetRequestMatcher(NewBlankRequestMatcher(
+		WithRequestMatcherFunc(
+			// attempt to destroy the requests at request matching time
+			func(httpRequest, trackRequest *track.Request) bool {
+				httpRequest = &track.Request{}
+				trackRequest = &track.Request{}
+				return true
+			},
+		),
+	))
 	suite.vcr.SetRecordingMutators(trackDestroyerMutator) // replace all existing mutators with this one
 	suite.vcr.ClearReplayingMutators()                    // remove mutators
 

--- a/pcb.go
+++ b/pcb.go
@@ -52,7 +52,10 @@ func (pcb *PrintedCircuitBoard) seekTrack(k7 *cassette.Cassette, httpRequest *ht
 func (pcb *PrintedCircuitBoard) trackMatches(k7 *cassette.Cassette, trackNumber int32, request *track.Request) bool {
 	trk := k7.Track(trackNumber)
 
-	return !trk.IsReplayed() && pcb.requestMatcher.Match(request, trk.GetRequest())
+	requestClone := request.Clone()
+	trackReqClone := trk.Request.Clone()
+
+	return !trk.IsReplayed() && pcb.requestMatcher.Match(requestClone, trackReqClone)
 }
 
 func (pcb *PrintedCircuitBoard) replayTrack(k7 *cassette.Cassette, trackNumber int32) (*track.Track, error) {


### PR DESCRIPTION
Also:
- removed track.GetRequest - the property is exported
- removed track.GetResponse - the property is exported
- small corrections / clarifications to README
- nil safe Stats
- added Request.Clone()
- removed cloneHeader() - Go has its own!
- added mutator.Predicate type for convenience
- linting: errors

Please, ensure your pull request meet these guidelines:

- [x] My code is written in TDD (test driven development) fashion.
- [x] My code adheres to Go standards
      I have run `make lint`,
      or I have used https://goreportcard.com/
      and I have taken the necessary compliance actions.
- [x] I have provided / updated examples.
- [x] I have updated [README.md].

Thanks for your PR, you're awesome! :+1:
