### PR TITLE
Add comment to cassette header

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ Refer to the tests for examples (search for `WithTrackRecordingMutators` and `Wi
 
 ## Cassette encryption
 
-Cassettes can be encrypted with the Go-supported AES-CGM cipher.
+Cassettes can be encrypted with the Go-supported AES-GCM cipher.
 
 You will need to provide a secret key of either 16 or 32 bytes to a "`Crypter`" that will take care of encrypting and decrypting the cassette contents transparently.
 
-The "nonce" is stored with the cassette, in its header. The default strategy to generate a nonce is a 12-byte random generator.
+The "nonce" is stored with the cassette, in its header. The default strategy to generate a nonce is a 12-byte random generator. This is only safe if the same key is reused at most 2³² times (which for a **govcr** cassette feels somewhat infinite).
 
 It is possible to provide a custom nonce generator, albeit currently this is somewhat limited because the current nonce is not provided. This can make it difficult to implement a counter, for example.
 

--- a/cassette/cassette_test.go
+++ b/cassette/cassette_test.go
@@ -129,7 +129,7 @@ func Test_cassette_Encryption(t *testing.T) {
 
 	// STEP 1: create encrypted cassette.
 	key := []byte("12345678901234567890123456789012")
-	c, err := encryption.NewAESCGM(key, nil)
+	c, err := encryption.NewAESGCMWithRandomNonceGenerator(key)
 	require.NoError(t, err)
 
 	k7 := cassette.NewCassette(cassetteName, cassette.WithCassetteCrypter(c))
@@ -149,7 +149,7 @@ func Test_cassette_Encryption(t *testing.T) {
 	data, err := os.ReadFile(cassetteName) // nolint:gosec
 	require.NoError(t, err)
 
-	const encryptedCassetteHeader = "$ENC$"
+	const encryptedCassetteHeader = "$ENC$" // AES-GCM encryption marker
 
 	require.True(t, bytes.HasPrefix(data, []byte(encryptedCassetteHeader)))
 
@@ -184,7 +184,7 @@ func Test_cassette_CanEncryptPlainCassette(t *testing.T) {
 
 	// STEP 1b: add track to cassette, this time encrypt the cassette.
 	key := []byte("12345678901234567890123456789012")
-	c, err := encryption.NewAESCGM(key, nil)
+	c, err := encryption.NewAESGCMWithRandomNonceGenerator(key)
 	require.NoError(t, err)
 
 	k7 = cassette.LoadCassette(cassetteName, cassette.WithCassetteCrypter(c))

--- a/cmd/govcr/main.go
+++ b/cmd/govcr/main.go
@@ -69,7 +69,7 @@ func decryptCassette(cassetteFile, keyFile string) (string, error) {
 		return "", errors.Wrap(err, "key file")
 	}
 
-	crypter, err := encryption.NewAESCGM(key, nil)
+	crypter, err := encryption.NewAESGCMWithRandomNonceGenerator(key)
 	if err != nil {
 		return "", errors.Wrap(err, "cryptographer")
 	}

--- a/encryption/aesgcm.go
+++ b/encryption/aesgcm.go
@@ -7,7 +7,13 @@ import (
 	cryptoerr "github.com/seborama/govcr/v8/encryption/errors"
 )
 
-// NewAESCGM creates a new Cryptor initialised with an AES-CGM cipher from the
+// NewAESGCMWithRandomNonceGenerator creates a new Cryptor initialised with an
+// AES-GCM cipher from the supplied key and the default nonce generator.
+func NewAESGCMWithRandomNonceGenerator(key []byte) (*Crypter, error) {
+	return NewAESGCM(key, &RandomNonceGenerator{})
+}
+
+// NewAESGCM creates a new Cryptor initialised with an AES-GCM cipher from the
 // supplied key.
 // The key is sensitive, never share it openly.
 //
@@ -15,9 +21,8 @@ import (
 //
 // If you want to convert a passphrase to a key, use a suitable
 // package like bcrypt or scrypt.
-// TODO: as nonceGenerator is not required, make it optional with a functional opt.
 // TODO: add a nonceGenerator validator i.e. call it 1000 times, ensures no dupes.
-func NewAESCGM(key []byte, nonceGenerator NonceGenerator) (*Crypter, error) {
+func NewAESGCM(key []byte, nonceGenerator NonceGenerator) (*Crypter, error) {
 	if len(key) != 16 && len(key) != 32 {
 		return nil, cryptoerr.NewErrCrypto("key size is not 16 or 32 bytes")
 	}
@@ -33,7 +38,7 @@ func NewAESCGM(key []byte, nonceGenerator NonceGenerator) (*Crypter, error) {
 	}
 
 	if nonceGenerator == nil {
-		nonceGenerator = &DefaultNonceGenerator{}
+		nonceGenerator = &RandomNonceGenerator{}
 	}
 
 	return &Crypter{

--- a/encryption/aesgcm_test.go
+++ b/encryption/aesgcm_test.go
@@ -12,15 +12,15 @@ import (
 func TestCryptor(t *testing.T) {
 	key := []byte("this is a test key______________")
 
-	aescgm, err := encryption.NewAESCGM(key, encryption.DefaultNonceGenerator{})
+	aesgcm, err := encryption.NewAESGCMWithRandomNonceGenerator(key)
 	require.NoError(t, err)
 
 	inputData := []byte("My little secret!")
 
-	ciphertext, nonce, err := aescgm.Encrypt(inputData)
+	ciphertext, nonce, err := aesgcm.Encrypt(inputData)
 	require.NoError(t, err)
 
-	plaintext, err := aescgm.Decrypt(ciphertext, nonce)
+	plaintext, err := aesgcm.Decrypt(ciphertext, nonce)
 	require.NoError(t, err)
 	assert.Equal(t, inputData, plaintext)
 }

--- a/encryption/nonce.go
+++ b/encryption/nonce.go
@@ -5,10 +5,10 @@ import (
 	"io"
 )
 
-type DefaultNonceGenerator struct{}
+type RandomNonceGenerator struct{}
 
 // Never use more than 2^32 random nonces with a given key because of the risk of a repeat.
-func (ng DefaultNonceGenerator) Generate() ([]byte, error) {
+func (ng RandomNonceGenerator) Generate() ([]byte, error) {
 	nonce := make([]byte, 12)
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, err

--- a/vcrsettings.go
+++ b/vcrsettings.go
@@ -37,7 +37,7 @@ func WithCassetteCrypto(keyFile string) CassetteOption {
 			panic(fmt.Sprintf("%+v", err))
 		}
 
-		crypter, err := encryption.NewAESCGM(key, nil)
+		crypter, err := encryption.NewAESGCMWithRandomNonceGenerator(key)
 		if err != nil {
 			panic(fmt.Sprintf("%+v", err))
 		}
@@ -55,7 +55,7 @@ func WithCassetteCryptoCustomNonce(keyFile string, nonceGenerator encryption.Non
 			panic(fmt.Sprintf("%+v", err))
 		}
 
-		crypter, err := encryption.NewAESCGM(key, nonceGenerator)
+		crypter, err := encryption.NewAESGCM(key, nonceGenerator)
 		if err != nil {
 			panic(fmt.Sprintf("%+v", err))
 		}


### PR DESCRIPTION
In the future, there may be other encryption modes than the current AES-GCM.

The comment implies that the `$ENC$` header in solely for AES-GCM.

If more encryption modes are added in the future, it's possible that the `$ENC$` header will be marked as deprecated and replaced with something like `$AES-GCM$`.

Also, fixed typos all over the place from AES-CGM to the correct AES-GCM.