### PR TITLE
-feat: remove LoadCassette, add CassetteMaker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,7 @@ test: deps cover
 
 lint: deps
 	./golangci-lint.sh || :
+
+bin: deps
+	go build -o bin/govcr ./cmd/govcr/...
+

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@
     <img src="https://github.com/seborama/govcr/actions/workflows/codeql-analysis.yml/badge.svg?branch=master" alt="govcr">
   </a>
 
-  <a href="https://pkg.go.dev/github.com/seborama/govcr/v9">
+  <a href="https://pkg.go.dev/github.com/seborama/govcr/v10">
     <img src="https://img.shields.io/badge/godoc-reference-blue.svg" alt="govcr">
   </a>
 
-  <a href="https://goreportcard.com/report/github.com/seborama/govcr/v9">
-    <img src="https://goreportcard.com/badge/github.com/seborama/govcr/v9" alt="govcr">
+  <a href="https://goreportcard.com/report/github.com/seborama/govcr/v10">
+    <img src="https://goreportcard.com/badge/github.com/seborama/govcr/v10" alt="govcr">
   </a>
 </p>
 
@@ -98,7 +98,7 @@ We use a "relaxed" request matcher because `example.com` injects an "`Age`" head
 ## Install
 
 ```bash
-go get github.com/seborama/govcr/v9@latest
+go get github.com/seborama/govcr/v10@latest
 ```
 
 For all available releases, please check the [releases](https://github.com/seborama/govcr/releases) tab on github.
@@ -106,7 +106,7 @@ For all available releases, please check the [releases](https://github.com/sebor
 And your source code would use this import:
 
 ```go
-import "github.com/seborama/govcr/v9"
+import "github.com/seborama/govcr/v10"
 ```
 
 For versions of **govcr** before v5 (which don't use go.mod), use a dependency manager to lock the version you wish to use (perhaps v4)!
@@ -136,7 +136,7 @@ go get gopkg.in/seborama/govcr.v4
 
 **govcr** is a wrapper around the Go `http.Client`. It can record live HTTP traffic to files (called "**cassettes**") and later replay HTTP requests ("**tracks**") from them instead of live HTTP calls.
 
-The code documentation can be found on [godoc](https://pkg.go.dev/github.com/seborama/govcr/v9).
+The code documentation can be found on [godoc](https://pkg.go.dev/github.com/seborama/govcr/v10).
 
 When using **govcr**'s `http.Client`, the request is matched against the **tracks** on the '**cassette**':
 
@@ -458,7 +458,7 @@ vcr := govcr.NewVCR(
 The command is located in the `cmd/govcr` folder, to install it:
 
 ```bash
-go install github.com/seborama/govcr/v9/cmd/govcr@latest
+go install github.com/seborama/govcr/v10/cmd/govcr@latest
 ```
 
 Example usage:

--- a/cassette/cassette_test.go
+++ b/cassette/cassette_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v9/cassette"
-	"github.com/seborama/govcr/v9/cassette/track"
-	"github.com/seborama/govcr/v9/encryption"
+	"github.com/seborama/govcr/v10/cassette"
+	"github.com/seborama/govcr/v10/cassette/track"
+	"github.com/seborama/govcr/v10/encryption"
 )
 
 func Test_cassette_GzipFilter(t *testing.T) {

--- a/cassette/cassette_wb_test.go
+++ b/cassette/cassette_wb_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/seborama/govcr/v9/stats"
+	"github.com/seborama/govcr/v10/stats"
 )
 
 func Test_cassette_NumberOfTracks_PanicsWhenNoCassette(t *testing.T) {

--- a/cassette/track/http_test.go
+++ b/cassette/track/http_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v9/cassette/track"
+	"github.com/seborama/govcr/v10/cassette/track"
 )
 
 func TestRequest_Clone(t *testing.T) {

--- a/cassette/track/mutator_test.go
+++ b/cassette/track/mutator_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v9/cassette/track"
+	"github.com/seborama/govcr/v10/cassette/track"
 )
 
 func Test_Mutator_On(t *testing.T) {

--- a/cassette/track/track.go
+++ b/cassette/track/track.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	trkerr "github.com/seborama/govcr/v9/cassette/track/errors"
+	trkerr "github.com/seborama/govcr/v10/cassette/track/errors"
 )
 
 // Track is a recording (HTTP Request + Response) in a cassette.

--- a/cmd/govcr/main.go
+++ b/cmd/govcr/main.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/seborama/govcr/v9/cassette"
-	"github.com/seborama/govcr/v9/encryption"
+	"github.com/seborama/govcr/v10/cassette"
+	"github.com/seborama/govcr/v10/encryption"
 )
 
 func main() {

--- a/controlpanel.go
+++ b/controlpanel.go
@@ -3,8 +3,8 @@ package govcr
 import (
 	"net/http"
 
-	"github.com/seborama/govcr/v9/cassette/track"
-	"github.com/seborama/govcr/v9/stats"
+	"github.com/seborama/govcr/v10/cassette/track"
+	"github.com/seborama/govcr/v10/stats"
 )
 
 // ControlPanel holds the parts of a VCR that can be interacted with.
@@ -16,15 +16,6 @@ type ControlPanel struct {
 // Stats returns Stats about the cassette and VCR session.
 func (controlPanel *ControlPanel) Stats() *stats.Stats {
 	return controlPanel.vcrTransport().stats()
-}
-
-// LoadCassette into the VCR.
-// Cassette options may be provided (e.g. cryptography).
-// Note: cassette.LoadCassette panics if the cassette exists but fails to load.
-func (controlPanel *ControlPanel) LoadCassette(cassetteName string, opts ...CassetteOption) error {
-	k7Opts := ToCassetteOptions(opts...)
-
-	return controlPanel.vcrTransport().loadCassette(cassetteName, k7Opts...)
 }
 
 // SetRequestMatcher sets a new RequestMatcher to the VCR.
@@ -88,11 +79,6 @@ func (controlPanel *ControlPanel) ClearReplayingMutators() {
 // HTTPClient returns the http.Client that contains the VCR.
 func (controlPanel *ControlPanel) HTTPClient() *http.Client {
 	return controlPanel.client
-}
-
-// EjectCassette from the VCR.
-func (controlPanel *ControlPanel) EjectCassette() {
-	controlPanel.vcrTransport().ejectCassette()
 }
 
 // NumberOfTracks returns the number of tracks contained in the cassette.

--- a/controlpanel_wb_test.go
+++ b/controlpanel_wb_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/seborama/govcr/v9/cassette/track"
+	"github.com/seborama/govcr/v10/cassette/track"
 )
 
 func TestControlPanel_SetRecordingMutators(t *testing.T) {

--- a/encryption/.study/rsa.go
+++ b/encryption/.study/rsa.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 
-	cryptoerr "github.com/seborama/govcr/v9/encryption/errors"
+	cryptoerr "github.com/seborama/govcr/v10/encryption/errors"
 )
 
 // nolint: deadcode

--- a/encryption/aesgcm.go
+++ b/encryption/aesgcm.go
@@ -4,7 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 
-	cryptoerr "github.com/seborama/govcr/v9/encryption/errors"
+	cryptoerr "github.com/seborama/govcr/v10/encryption/errors"
 )
 
 // NewAESGCMWithRandomNonceGenerator creates a new Cryptor initialised with an

--- a/encryption/aesgcm_test.go
+++ b/encryption/aesgcm_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v9/encryption"
+	"github.com/seborama/govcr/v10/encryption"
 )
 
 func TestCryptor_AESGCM(t *testing.T) {

--- a/encryption/chacha20poly1305_test.go
+++ b/encryption/chacha20poly1305_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v9/encryption"
+	"github.com/seborama/govcr/v10/encryption"
 )
 
 func TestCryptor_ChaCha20Poly1305(t *testing.T) {

--- a/examples/Example1_test.go
+++ b/examples/Example1_test.go
@@ -4,10 +4,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/seborama/govcr/v9"
-	"github.com/seborama/govcr/v9/stats"
+	"github.com/seborama/govcr/v10"
+	"github.com/seborama/govcr/v10/stats"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const exampleCassetteName1 = "temp-fixtures/TestExample1.cassette.json"
@@ -17,7 +16,7 @@ func TestExample1(t *testing.T) {
 	_ = os.Remove(exampleCassetteName1)
 
 	vcr := govcr.NewVCR(
-		govcr.WithCassette(exampleCassetteName1),
+		govcr.NewCassetteMaker(exampleCassetteName1),
 		govcr.WithRequestMatcher(govcr.NewMethodURLRequestMatcher()), // use a "relaxed" request matcher
 	)
 
@@ -36,9 +35,10 @@ func TestExample1(t *testing.T) {
 
 	// The second request will be transparently replayed from the cassette by govcr
 	// No live HTTP request is placed to the live server
-	vcr.EjectCassette()
-	err := vcr.LoadCassette(exampleCassetteName1)
-	require.NoError(t, err)
+	vcr = govcr.NewVCR(
+		govcr.NewCassetteMaker(exampleCassetteName1),
+		govcr.WithRequestMatcher(govcr.NewMethodURLRequestMatcher()), // use a "relaxed" request matcher
+	)
 
 	vcr.HTTPClient().Get("http://example.com/foo")
 	assert.Equal(

--- a/examples/Example2_test.go
+++ b/examples/Example2_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seborama/govcr/v9"
+	"github.com/seborama/govcr/v10"
 )
 
 const exampleCassetteName2 = "temp-fixtures/TestExample2.cassette.json"
@@ -39,7 +39,7 @@ func TestExample2(t *testing.T) {
 
 	// Instantiate VCR.
 	vcr := govcr.NewVCR(
-		govcr.WithCassette(exampleCassetteName2),
+		govcr.NewCassetteMaker(exampleCassetteName2),
 		govcr.WithClient(app.httpClient),
 	)
 

--- a/examples/Example4_test.go
+++ b/examples/Example4_test.go
@@ -4,11 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/seborama/govcr/v9"
-	"github.com/seborama/govcr/v9/encryption"
-	"github.com/seborama/govcr/v9/stats"
+	"github.com/seborama/govcr/v10"
+	"github.com/seborama/govcr/v10/encryption"
+	"github.com/seborama/govcr/v10/stats"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const exampleCassetteName4 = "temp-fixtures/TestExample4.cassette.json"
@@ -19,12 +18,10 @@ func TestExample4(t *testing.T) {
 	_ = os.Remove(exampleCassetteName4)
 
 	vcr := govcr.NewVCR(
-		govcr.WithCassette(
-			exampleCassetteName4,
-			govcr.WithCassetteCrypto(
+		govcr.NewCassetteMaker(exampleCassetteName4).
+			WithCassetteCrypto(
 				encryption.NewChaCha20Poly1305WithRandomNonceGenerator,
 				"test-fixtures/TestExample4.unsafe.key"),
-		),
 		govcr.WithRequestMatcher(govcr.NewMethodURLRequestMatcher()), // use a "relaxed" request matcher
 	)
 
@@ -43,12 +40,12 @@ func TestExample4(t *testing.T) {
 
 	// The second request will be transparently replayed from the cassette by govcr
 	// No live HTTP request is placed to the live server
-	vcr.EjectCassette()
-	err := vcr.LoadCassette(
-		exampleCassetteName4,
-		govcr.WithCassetteCrypto(encryption.NewChaCha20Poly1305WithRandomNonceGenerator, "test-fixtures/TestExample4.unsafe.key"),
+	vcr = govcr.NewVCR(
+		govcr.NewCassetteMaker(exampleCassetteName4).
+			WithCassetteCrypto(
+				encryption.NewChaCha20Poly1305WithRandomNonceGenerator,
+				"test-fixtures/TestExample4.unsafe.key"),
 	)
-	require.NoError(t, err)
 
 	vcr.HTTPClient().Get("http://example.com/foo")
 	assert.Equal(

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/seborama/govcr/v9
+module github.com/seborama/govcr/v10
 
 go 1.17
 

--- a/govcr.go
+++ b/govcr.go
@@ -1,10 +1,83 @@
 package govcr
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/seborama/govcr/v10/cassette"
+	"github.com/seborama/govcr/v10/encryption"
+)
+
+// CrypterProvider is the signature of a cipher provider function with default nonce generator.
+// Examples are encryption.NewAESGCMWithRandomNonceGenerator and
+// encryption.NewChaCha20Poly1305WithRandomNonceGenerator.
+type CrypterProvider func(key []byte) (*encryption.Crypter, error)
+
+// CrypterNonceProvider is the signature of a cipher provider function with custom nonce generator.
+// Examples are encryption.NewAESGCM and encryption.NewChaCha20Poly1305.
+type CrypterNonceProvider func(key []byte, nonceGenerator encryption.NonceGenerator) (*encryption.Crypter, error)
+
+// CassetteMaker helps build a cassette to load in the VCR.
+type CassetteMaker struct {
+	cassetteName string
+	opts         []cassette.Option
+}
+
+// NewCassetteMaker creates a new CassetteMaker, initialised with the cassette's name.
+func NewCassetteMaker(cassetteName string) *CassetteMaker {
+	return &CassetteMaker{
+		cassetteName: cassetteName,
+	}
+}
+
+// WithCassetteCrypto creates a cassette cryptographer with the specified cipher function
+// and key file.
+// Only use WithCassetteCrypto or WithCassetteCrypto*. Using both is ambiguous.
+func (cb *CassetteMaker) WithCassetteCrypto(crypter CrypterProvider, keyFile string) *CassetteMaker {
+	f := func(key []byte, nonceGenerator encryption.NonceGenerator) (*encryption.Crypter, error) {
+		// a "CrypterProvider" is a CrypterNonceProvider with a pre-defined / default nonceGenerator
+		return crypter(key)
+	}
+
+	return cb.WithCassetteCryptoCustomNonce(f, keyFile, nil)
+}
+
+// WithCassetteCryptoCustomNonce creates a cassette cryptographer with the specified key file and
+// customer nonce generator.
+// Only use WithCassetteCrypto or WithCassetteCrypto*. Using both is ambiguous.
+func (cb *CassetteMaker) WithCassetteCryptoCustomNonce(crypterNonce CrypterNonceProvider, keyFile string, nonceGenerator encryption.NonceGenerator) *CassetteMaker {
+	key, err := os.ReadFile(keyFile)
+	if err != nil {
+		panic(fmt.Sprintf("%+v", err))
+	}
+
+	cr, err := crypterNonce(key, nonceGenerator)
+	if err != nil {
+		panic(fmt.Sprintf("%+v", err))
+	}
+
+	cb.opts = append(cb.opts, cassette.WithCassetteCrypter(cr))
+
+	return cb
+}
+
+// WithCassette is an optional functional parameter to provide a VCR with
+// a cassette to load.
+// Cassette options may be provided (e.g. cryptography).
+func (cb *CassetteMaker) make() *cassette.Cassette {
+	if cb == nil {
+		panic("please select a cassette for the VCR")
+	}
+
+	return cassette.LoadCassette(cb.cassetteName, cb.opts...)
+}
 
 // NewVCR creates a new VCR.
-func NewVCR(settings ...Setting) *ControlPanel {
+func NewVCR(cassetteMaker *CassetteMaker, settings ...Setting) *ControlPanel {
 	var vcrSettings VCRSettings
+
+	vcrSettings.cassette = cassetteMaker.make()
 
 	for _, option := range settings {
 		option(&vcrSettings)

--- a/matchers.go
+++ b/matchers.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/seborama/govcr/v9/cassette/track"
+	"github.com/seborama/govcr/v10/cassette/track"
 )
 
 // RequestMatcherFunc is a function that performs request comparison.

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/seborama/govcr/v9"
-	"github.com/seborama/govcr/v9/cassette/track"
+	"github.com/seborama/govcr/v10"
+	"github.com/seborama/govcr/v10/cassette/track"
 )
 
 func Test_DefaultHeaderMatcher(t *testing.T) {

--- a/pcb.go
+++ b/pcb.go
@@ -3,8 +3,8 @@ package govcr
 import (
 	"net/http"
 
-	"github.com/seborama/govcr/v9/cassette"
-	"github.com/seborama/govcr/v9/cassette/track"
+	"github.com/seborama/govcr/v10/cassette"
+	"github.com/seborama/govcr/v10/cassette/track"
 )
 
 // HTTPMode defines govcr's mode for HTTP requests.

--- a/pcb_wb_test.go
+++ b/pcb_wb_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v9/cassette"
-	"github.com/seborama/govcr/v9/cassette/track"
+	"github.com/seborama/govcr/v10/cassette"
+	"github.com/seborama/govcr/v10/cassette/track"
 )
 
 func TestPrintedCircuitBoard_trackMatches(t *testing.T) {


### PR DESCRIPTION
LoadCassette didn't add value but caused some side-effects and inadequate patterns of usage.

This simplifies and clarifies initialisation code.

Added `CassetteMaker` to help create a new cassette.

The name `CassetteMaker` may change in the future.

Please, ensure your pull request meet these guidelines:

- [x] My code is written in TDD (test driven development) fashion.
- [x] My code adheres to Go standards
      I have run `make lint`,
      or I have used https://goreportcard.com/
      and I have taken the necessary compliance actions.
- [x] I have provided / updated examples.
- [x] I have updated [README.md].

Thanks for your PR, you're awesome! :+1:
