### PR TITLE
BREAKING CHANGE: Simplify and consolidate RequestMatcher usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@
     <img src="https://github.com/seborama/govcr/actions/workflows/codeql-analysis.yml/badge.svg?branch=master" alt="govcr">
   </a>
 
-  <a href="https://pkg.go.dev/github.com/seborama/govcr/v11">
+  <a href="https://pkg.go.dev/github.com/seborama/govcr/v12">
     <img src="https://img.shields.io/badge/godoc-reference-blue.svg" alt="govcr">
   </a>
 
-  <a href="https://goreportcard.com/report/github.com/seborama/govcr/v11">
-    <img src="https://goreportcard.com/badge/github.com/seborama/govcr/v11" alt="govcr">
+  <a href="https://goreportcard.com/report/github.com/seborama/govcr/v12">
+    <img src="https://goreportcard.com/badge/github.com/seborama/govcr/v12" alt="govcr">
   </a>
 </p>
 
@@ -97,7 +97,7 @@ We use a "relaxed" request matcher because `example.com` injects an "`Age`" head
 ## Install
 
 ```bash
-go get github.com/seborama/govcr/v11@latest
+go get github.com/seborama/govcr/v12@latest
 ```
 
 For all available releases, please check the [releases](https://github.com/seborama/govcr/releases) tab on github.
@@ -105,7 +105,7 @@ For all available releases, please check the [releases](https://github.com/sebor
 And your source code would use this import:
 
 ```go
-import "github.com/seborama/govcr/v11"
+import "github.com/seborama/govcr/v12"
 ```
 
 For versions of **govcr** before v5 (which don't use go.mod), use a dependency manager to lock the version you wish to use (perhaps v4)!
@@ -135,7 +135,7 @@ go get gopkg.in/seborama/govcr.v4
 
 **govcr** is a wrapper around the Go `http.Client`. It can record live HTTP traffic to files (called "**cassettes**") and later replay HTTP requests ("**tracks**") from them instead of live HTTP calls.
 
-The code documentation can be found on [godoc](https://pkg.go.dev/github.com/seborama/govcr/v11).
+The code documentation can be found on [godoc](https://pkg.go.dev/github.com/seborama/govcr/v12).
 
 When using **govcr**'s `http.Client`, the request is matched against the **tracks** on the '**cassette**':
 
@@ -437,7 +437,7 @@ vcr := govcr.NewVCR(
 The command is located in the `cmd/govcr` folder, to install it:
 
 ```bash
-go install github.com/seborama/govcr/v11/cmd/govcr@latest
+go install github.com/seborama/govcr/v12/cmd/govcr@latest
 ```
 
 Example usage:

--- a/cassette/cassette.go
+++ b/cassette/cassette.go
@@ -14,11 +14,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
-	"github.com/seborama/govcr/v11/cassette/track"
-	"github.com/seborama/govcr/v11/compression"
-	cryptoerr "github.com/seborama/govcr/v11/encryption/errors"
-	govcrerr "github.com/seborama/govcr/v11/errors"
-	"github.com/seborama/govcr/v11/stats"
+	"github.com/seborama/govcr/v12/cassette/track"
+	"github.com/seborama/govcr/v12/compression"
+	cryptoerr "github.com/seborama/govcr/v12/encryption/errors"
+	govcrerr "github.com/seborama/govcr/v12/errors"
+	"github.com/seborama/govcr/v12/stats"
 )
 
 // Cassette contains a set of tracks.

--- a/cassette/cassette_test.go
+++ b/cassette/cassette_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v11/cassette"
-	"github.com/seborama/govcr/v11/cassette/track"
-	"github.com/seborama/govcr/v11/encryption"
+	"github.com/seborama/govcr/v12/cassette"
+	"github.com/seborama/govcr/v12/cassette/track"
+	"github.com/seborama/govcr/v12/encryption"
 )
 
 func Test_cassette_GzipFilter(t *testing.T) {

--- a/cassette/cassette_wb_test.go
+++ b/cassette/cassette_wb_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/seborama/govcr/v11/stats"
+	"github.com/seborama/govcr/v12/stats"
 )
 
 func Test_cassette_NumberOfTracks_PanicsWhenNoCassette(t *testing.T) {

--- a/cassette/track/http_test.go
+++ b/cassette/track/http_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v11/cassette/track"
+	"github.com/seborama/govcr/v12/cassette/track"
 )
 
 func TestRequest_Clone(t *testing.T) {

--- a/cassette/track/mutator_test.go
+++ b/cassette/track/mutator_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v11/cassette/track"
+	"github.com/seborama/govcr/v12/cassette/track"
 )
 
 func Test_Mutator_On(t *testing.T) {

--- a/cassette/track/track.go
+++ b/cassette/track/track.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	trkerr "github.com/seborama/govcr/v11/cassette/track/errors"
+	trkerr "github.com/seborama/govcr/v12/cassette/track/errors"
 )
 
 // Track is a recording (HTTP Request + Response) in a cassette.

--- a/cmd/govcr/main.go
+++ b/cmd/govcr/main.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/seborama/govcr/v11/cassette"
-	"github.com/seborama/govcr/v11/encryption"
+	"github.com/seborama/govcr/v12/cassette"
+	"github.com/seborama/govcr/v12/encryption"
 )
 
 func main() {

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v11"
-	"github.com/seborama/govcr/v11/stats"
+	"github.com/seborama/govcr/v12"
+	"github.com/seborama/govcr/v12/stats"
 )
 
 func TestConcurrencySafety(t *testing.T) {

--- a/controlpanel.go
+++ b/controlpanel.go
@@ -3,8 +3,8 @@ package govcr
 import (
 	"net/http"
 
-	"github.com/seborama/govcr/v11/cassette/track"
-	"github.com/seborama/govcr/v11/stats"
+	"github.com/seborama/govcr/v12/cassette/track"
+	"github.com/seborama/govcr/v12/stats"
 )
 
 // ControlPanel holds the parts of a VCR that can be interacted with.

--- a/controlpanel_wb_test.go
+++ b/controlpanel_wb_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/seborama/govcr/v11/cassette/track"
+	"github.com/seborama/govcr/v12/cassette/track"
 )
 
 func TestControlPanel_SetRecordingMutators(t *testing.T) {

--- a/encryption/.study/rsa.go
+++ b/encryption/.study/rsa.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 
-	cryptoerr "github.com/seborama/govcr/v11/encryption/errors"
+	cryptoerr "github.com/seborama/govcr/v12/encryption/errors"
 )
 
 // nolint: deadcode

--- a/encryption/aesgcm.go
+++ b/encryption/aesgcm.go
@@ -4,7 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 
-	cryptoerr "github.com/seborama/govcr/v11/encryption/errors"
+	cryptoerr "github.com/seborama/govcr/v12/encryption/errors"
 )
 
 // NewAESGCMWithRandomNonceGenerator creates a new Cryptor initialised with an

--- a/encryption/aesgcm_test.go
+++ b/encryption/aesgcm_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v11/encryption"
+	"github.com/seborama/govcr/v12/encryption"
 )
 
 func TestCryptor_AESGCM(t *testing.T) {

--- a/encryption/chacha20poly1305_test.go
+++ b/encryption/chacha20poly1305_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v11/encryption"
+	"github.com/seborama/govcr/v12/encryption"
 )
 
 func TestCryptor_ChaCha20Poly1305(t *testing.T) {

--- a/examples/Example1_test.go
+++ b/examples/Example1_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/seborama/govcr/v11"
-	"github.com/seborama/govcr/v11/stats"
+	"github.com/seborama/govcr/v12"
+	"github.com/seborama/govcr/v12/stats"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/examples/Example2_test.go
+++ b/examples/Example2_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seborama/govcr/v11"
+	"github.com/seborama/govcr/v12"
 )
 
 const exampleCassetteName2 = "temp-fixtures/TestExample2.cassette.json"

--- a/examples/Example3_test.go
+++ b/examples/Example3_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/seborama/govcr/v11"
-	"github.com/seborama/govcr/v11/cassette/track"
+	"github.com/seborama/govcr/v12"
+	"github.com/seborama/govcr/v12/cassette/track"
 	"github.com/stretchr/testify/require"
 )
 

--- a/examples/Example3_test.go
+++ b/examples/Example3_test.go
@@ -21,19 +21,15 @@ func TestExample3(t *testing.T) {
 	// Instantiate VCR.
 	vcr := govcr.NewVCR(
 		govcr.NewCassetteLoader(exampleCassetteName3),
-		govcr.WithRequestMatcher(
-			govcr.NewBlankRequestMatcher(
-				govcr.WithRequestMatcherFunc(
-					func(httpRequest, trackRequest *track.Request) bool {
-						// Remove the header from comparison.
-						// Note: this removal is only scoped to the request matcher, it does not affect the original HTTP request
-						httpRequest.Header.Del("X-Transaction-Id")
-						trackRequest.Header.Del("X-Transaction-Id")
+		govcr.WithRequestMatcherFuncs(
+			func(httpRequest, trackRequest *track.Request) bool {
+				// Remove the header from comparison.
+				// Note: this removal is only scoped to the request matcher, it does not affect the original HTTP request
+				httpRequest.Header.Del("X-Transaction-Id")
+				trackRequest.Header.Del("X-Transaction-Id")
 
-						return govcr.DefaultHeaderMatcher(httpRequest, trackRequest)
-					},
-				),
-			),
+				return govcr.DefaultHeaderMatcher(httpRequest, trackRequest)
+			},
 		),
 		govcr.WithTrackReplayingMutators(
 			// Note: although we deleted the headers in the request matcher, this was limited to the scope of

--- a/examples/Example4_test.go
+++ b/examples/Example4_test.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/seborama/govcr/v11"
-	"github.com/seborama/govcr/v11/encryption"
-	"github.com/seborama/govcr/v11/stats"
+	"github.com/seborama/govcr/v12"
+	"github.com/seborama/govcr/v12/encryption"
+	"github.com/seborama/govcr/v12/stats"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/seborama/govcr/v11
+module github.com/seborama/govcr/v12
 
 go 1.17
 

--- a/govcr.go
+++ b/govcr.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/seborama/govcr/v11/cassette"
-	"github.com/seborama/govcr/v11/encryption"
+	"github.com/seborama/govcr/v12/cassette"
+	"github.com/seborama/govcr/v12/encryption"
 )
 
 // CrypterProvider is the signature of a cipher provider function with default nonce generator.

--- a/govcr_test.go
+++ b/govcr_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/seborama/govcr/v11"
-	"github.com/seborama/govcr/v11/stats"
+	"github.com/seborama/govcr/v12"
+	"github.com/seborama/govcr/v12/stats"
 )
 
 func TestNewVCR(t *testing.T) {

--- a/govcr_test.go
+++ b/govcr_test.go
@@ -168,7 +168,7 @@ func (ts *GoVCRTestSuite) TestVCR_LiveOnlyMode() {
 	// 1st execution of set of calls
 	vcr := ts.newVCR(k7Name, actionDeleteCassette)
 	vcr.SetLiveOnlyMode()
-	vcr.SetRequestMatcher(govcr.NewBlankRequestMatcher()) // ensure always matching
+	vcr.SetRequestMatcher(govcr.NewRequestMatcherCollection()) // ensure always matching
 
 	ts.makeHTTPCalls_WithSuccess(vcr.HTTPClient(), 0)
 	expectedStats := &stats.Stats{
@@ -183,7 +183,7 @@ func (ts *GoVCRTestSuite) TestVCR_LiveOnlyMode() {
 	// 2nd execution of set of calls
 	vcr = ts.newVCR(k7Name, actionKeepCassette)
 	vcr.SetLiveOnlyMode()
-	vcr.SetRequestMatcher(govcr.NewBlankRequestMatcher()) // ensure always matching
+	vcr.SetRequestMatcher(govcr.NewRequestMatcherCollection()) // ensure always matching
 
 	ts.makeHTTPCalls_WithSuccess(vcr.HTTPClient(), 2) // as we're making live requests, the sever keeps on increasing the counter
 	expectedStats = &stats.Stats{
@@ -200,8 +200,8 @@ func (ts *GoVCRTestSuite) TestVCR_OfflineMode() {
 
 	// 1st execution of set of calls - populate cassette
 	vcr := ts.newVCR(k7Name, actionDeleteCassette)
-	vcr.SetRequestMatcher(govcr.NewBlankRequestMatcher()) // ensure always matching
-	vcr.SetNormalMode()                                   // get data in the cassette
+	vcr.SetRequestMatcher(govcr.NewRequestMatcherCollection()) // ensure always matching
+	vcr.SetNormalMode()                                        // get data in the cassette
 
 	ts.makeHTTPCalls_WithSuccess(vcr.HTTPClient(), 0)
 	expectedStats := &stats.Stats{

--- a/govcr_wb_test.go
+++ b/govcr_wb_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/seborama/govcr/v11/cassette/track"
-	"github.com/seborama/govcr/v11/stats"
+	"github.com/seborama/govcr/v12/cassette/track"
+	"github.com/seborama/govcr/v12/stats"
 )
 
 type GoVCRWBTestSuite struct {

--- a/govcr_wb_test.go
+++ b/govcr_wb_test.go
@@ -77,27 +77,25 @@ func (ts *GoVCRWBTestSuite) TestRoundTrip_RequestMatcherDoesNotMutateState() {
 
 	requestMatcherCount := 0
 
-	reqMatcher := func(outcome bool) *DefaultRequestMatcher {
-		return NewBlankRequestMatcher(
-			WithRequestMatcherFunc(
-				// attempt to mutate state
-				func(httpRequest, trackRequest *track.Request) bool {
-					requestMatcherCount++
+	reqMatcher := func(outcome bool) *RequestMatcherCollection {
+		return NewRequestMatcherCollection(
+			// attempt to mutate state
+			func(httpRequest, trackRequest *track.Request) bool {
+				requestMatcherCount++
 
-					httpRequest.Method = "test"
-					httpRequest.URL = &url.URL{}
-					httpRequest.Body = nil
+				httpRequest.Method = "test"
+				httpRequest.URL = &url.URL{}
+				httpRequest.Body = nil
 
-					trackRequest.Method = "test"
-					trackRequest.URL = &url.URL{}
-					trackRequest.Body = nil
+				trackRequest.Method = "test"
+				trackRequest.URL = &url.URL{}
+				trackRequest.Body = nil
 
-					httpRequest = &track.Request{}  //nolint:staticcheck
-					trackRequest = &track.Request{} //nolint:staticcheck
+				httpRequest = &track.Request{}  //nolint:staticcheck
+				trackRequest = &track.Request{} //nolint:staticcheck
 
-					return outcome
-				},
-			),
+				return outcome
+			},
 		)
 	}
 

--- a/matchers.go
+++ b/matchers.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/seborama/govcr/v11/cassette/track"
+	"github.com/seborama/govcr/v12/cassette/track"
 )
 
 // RequestMatcherFunc is a function that performs request comparison.

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/seborama/govcr/v11"
-	"github.com/seborama/govcr/v11/cassette/track"
+	"github.com/seborama/govcr/v12"
+	"github.com/seborama/govcr/v12/cassette/track"
 )
 
 func Test_DefaultHeaderMatcher(t *testing.T) {

--- a/pcb.go
+++ b/pcb.go
@@ -3,8 +3,8 @@ package govcr
 import (
 	"net/http"
 
-	"github.com/seborama/govcr/v11/cassette"
-	"github.com/seborama/govcr/v11/cassette/track"
+	"github.com/seborama/govcr/v12/cassette"
+	"github.com/seborama/govcr/v12/cassette/track"
 )
 
 // HTTPMode defines govcr's mode for HTTP requests.

--- a/pcb_wb_test.go
+++ b/pcb_wb_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v11/cassette"
-	"github.com/seborama/govcr/v11/cassette/track"
+	"github.com/seborama/govcr/v12/cassette"
+	"github.com/seborama/govcr/v12/cassette/track"
 )
 
 func TestPrintedCircuitBoard_trackMatches(t *testing.T) {

--- a/pcb_wb_test.go
+++ b/pcb_wb_test.go
@@ -19,47 +19,45 @@ func TestPrintedCircuitBoard_trackMatches(t *testing.T) {
 	// This test is in addition toTestRoundTrip_RequestMatcherDoesNotMutateState
 	pcb := &PrintedCircuitBoard{}
 	pcb.SetRequestMatcher(
-		NewBlankRequestMatcher(
-			WithRequestMatcherFunc(
-				func(httpRequest, trackRequest *track.Request) bool {
-					for k := range httpRequest.Header {
-						httpRequest.Header.Set(k, "nil")
-					}
-					for i := range httpRequest.Body {
-						httpRequest.Body[i] = 'X'
-					}
-					httpRequest.ContentLength = -1
-					for k := range httpRequest.MultipartForm.File {
-						for k2 := range httpRequest.MultipartForm.File[k] {
-							httpRequest.MultipartForm.File[k][k2].Filename = "nil"
-							for k3 := range httpRequest.MultipartForm.File[k][k2].Header {
-								httpRequest.MultipartForm.File[k][k2].Header.Set(k3, "nil")
-							}
+		NewRequestMatcherCollection(
+			func(httpRequest, trackRequest *track.Request) bool {
+				for k := range httpRequest.Header {
+					httpRequest.Header.Set(k, "nil")
+				}
+				for i := range httpRequest.Body {
+					httpRequest.Body[i] = 'X'
+				}
+				httpRequest.ContentLength = -1
+				for k := range httpRequest.MultipartForm.File {
+					for k2 := range httpRequest.MultipartForm.File[k] {
+						httpRequest.MultipartForm.File[k][k2].Filename = "nil"
+						for k3 := range httpRequest.MultipartForm.File[k][k2].Header {
+							httpRequest.MultipartForm.File[k][k2].Header.Set(k3, "nil")
 						}
 					}
+				}
 
-					for k := range trackRequest.Header {
-						trackRequest.Header.Set(k, "nil")
-					}
-					for i := range trackRequest.Body {
-						trackRequest.Body[i] = 'X'
-					}
-					trackRequest.ContentLength = -1
-					for k := range trackRequest.MultipartForm.File {
-						for k2 := range trackRequest.MultipartForm.File[k] {
-							trackRequest.MultipartForm.File[k][k2].Filename = "nil"
-							for k3 := range trackRequest.MultipartForm.File[k][k2].Header {
-								trackRequest.MultipartForm.File[k][k2].Header.Set(k3, "nil")
-							}
+				for k := range trackRequest.Header {
+					trackRequest.Header.Set(k, "nil")
+				}
+				for i := range trackRequest.Body {
+					trackRequest.Body[i] = 'X'
+				}
+				trackRequest.ContentLength = -1
+				for k := range trackRequest.MultipartForm.File {
+					for k2 := range trackRequest.MultipartForm.File[k] {
+						trackRequest.MultipartForm.File[k][k2].Filename = "nil"
+						for k3 := range trackRequest.MultipartForm.File[k][k2].Header {
+							trackRequest.MultipartForm.File[k][k2].Header.Set(k3, "nil")
 						}
 					}
+				}
 
-					httpRequest = nil
-					trackRequest = nil
+				httpRequest = nil
+				trackRequest = nil
 
-					return true
-				},
-			),
+				return true
+			},
 		),
 	)
 

--- a/vcrsettings.go
+++ b/vcrsettings.go
@@ -27,6 +27,17 @@ func WithRequestMatcher(matcher RequestMatcher) Setting {
 	}
 }
 
+// WithRequestMatcherFuncs is syntactic sugar for
+// WithRequestMatcher(NewRequestMatcherCollection(...)).
+// It allows to add a RequestMatcher straight from a collection of RequestMatcherFunc.
+//
+// See also: WithRequestMatcher and NewRequestMatcherCollection.
+func WithRequestMatcherFuncs(matcherFuncs ...RequestMatcherFunc) Setting {
+	return func(vcrSettings *VCRSettings) {
+		vcrSettings.requestMatcher = NewRequestMatcherCollection(matcherFuncs...)
+	}
+}
+
 // WithTrackRecordingMutators is an optional functional parameter to provide a VCR with
 // a set of track mutators applied when recording a track to a cassette.
 func WithTrackRecordingMutators(trackRecordingMutators ...track.Mutator) Setting {

--- a/vcrsettings.go
+++ b/vcrsettings.go
@@ -3,8 +3,8 @@ package govcr
 import (
 	"net/http"
 
-	"github.com/seborama/govcr/v11/cassette"
-	"github.com/seborama/govcr/v11/cassette/track"
+	"github.com/seborama/govcr/v12/cassette"
+	"github.com/seborama/govcr/v12/cassette/track"
 )
 
 // Setting defines an optional functional parameter as received by NewVCR().

--- a/vcrtransport.go
+++ b/vcrtransport.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/seborama/govcr/v11/cassette"
-	"github.com/seborama/govcr/v11/cassette/track"
-	govcrerr "github.com/seborama/govcr/v11/errors"
-	"github.com/seborama/govcr/v11/stats"
+	"github.com/seborama/govcr/v12/cassette"
+	"github.com/seborama/govcr/v12/cassette/track"
+	govcrerr "github.com/seborama/govcr/v12/errors"
+	"github.com/seborama/govcr/v12/stats"
 )
 
 // vcrTransport is the heart of VCR. It implements


### PR DESCRIPTION
BREAKING CHANGE: renamed NewBlankRequestMatcher to NewRequestMatcherCollection with a simpler signature
BREAKING CHANGE: removed RequestMatcherCollectionOptions
BREAKING CHANGE: removed WithRequestMatcherFunc (singular form)
BREAKING CHANGE: renamed DefaultRequestMatcher to RequestMatcherCollection
feat: added WithRequestMatcherFuncs as syntactic sugar for WithRequestMatcher(NewRequestMatcherCollection(...))

Please, ensure your pull request meet these guidelines:

- [x] My code is written in TDD (test driven development) fashion.
- [x] My code adheres to Go standards
      I have run `make lint`,
      or I have used https://goreportcard.com/
      and I have taken the necessary compliance actions.
- [x] I have provided / updated examples.
- [x] I have updated [README.md].

Thanks for your PR, you're awesome! :+1:
