### PR TITLE
fix: do not write request in cassette response struct

### DIFF
--- a/cassette/cassette_test.go
+++ b/cassette/cassette_test.go
@@ -2,6 +2,7 @@ package cassette_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -49,6 +50,33 @@ func Test_cassette_GzipFilter(t *testing.T) {
 			assert.EqualValues(t, tc.want, got)
 		})
 	}
+}
+
+func Test_cassette_AddTrackToCassette(t *testing.T) {
+	t.Run("Nested request is discarded", func(t *testing.T) {
+		s := &StoreMock{}
+		k7 := cassette.NewCassette("", cassette.WithStore(s))
+
+		req := &track.Request{}
+		res := &track.Response{}
+		res.Request = req
+
+		tr := track.NewTrack(req, res, nil)
+
+		err := cassette.AddTrackToCassette(k7, tr)
+		require.NoError(t, err)
+
+		if assert.NotNil(t, s.Data) {
+			var got cassette.Cassette
+			err = json.Unmarshal(s.Data, &got)
+			require.NoError(t, err)
+			require.Len(t, got.Tracks, 1)
+
+			// Make sure the request has not made it into the saved cassette attached to the response.
+			assert.NotNil(t, got.Tracks[0].Request)
+			assert.Nil(t, got.Tracks[0].Response.Request)
+		}
+	})
 }
 
 func Test_cassette_IsLongPlay(t *testing.T) {
@@ -220,4 +248,25 @@ func Test_cassette_CanEncryptPlainCassette(t *testing.T) {
 	}
 
 	require.Equal(t, k7.Tracks, k8.Tracks)
+}
+
+type StoreMock struct {
+	Data []byte
+}
+
+func (s *StoreMock) MkdirAll(path string, perm os.FileMode) error {
+	return nil
+}
+
+func (s *StoreMock) ReadFile(name string) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *StoreMock) WriteFile(name string, data []byte, perm os.FileMode) error {
+	s.Data = data
+	return nil
+}
+
+func (s *StoreMock) NotExist(name string) (bool, error) {
+	return false, nil
 }

--- a/cassette/track/http.go
+++ b/cassette/track/http.go
@@ -194,7 +194,7 @@ type Response struct {
 	// This is useful in scenarios where the request contains a dynamic piece of information
 	// such as e.g. a transaction ID, a customer number, etc.
 	// This is solely for informational purpose at replaying time. Mutating it achieves nothing.
-	Request *Request
+	Request *Request `json:"-"`
 }
 
 // ToResponse transcodes an HTTP Response to a track Response.


### PR DESCRIPTION
Add a `json:"-"` struct tag to the Response.Request field, to make sure this field is never saved to disk.

This fixes a case where the Response.Request field is populated during a replay, and then a new track is added, causing the cassette to be re-saved to disk, including the request field.

This case is especially problematic in cases where a `TrackRecordingMutator` has been used to remove sensitive information from the request, since the nested request was not covered by the mutator.

- [x] My code is written in TDD (test driven development) fashion.
- [x] My code adheres to Go standards
      I have run `make lint`,
      or I have used https://goreportcard.com/
      and I have taken the necessary compliance actions.
- [ ] I have provided / updated examples.
- [ ] I have updated [README.md].