### PR TITLE
fix: do not write request in cassette response struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@
     <img src="https://github.com/seborama/govcr/actions/workflows/codeql-analysis.yml/badge.svg?branch=master" alt="govcr">
   </a>
 
-  <a href="https://pkg.go.dev/github.com/seborama/govcr/v16">
+  <a href="https://pkg.go.dev/github.com/seborama/govcr/v17">
     <img src="https://img.shields.io/badge/godoc-reference-blue.svg" alt="govcr">
   </a>
 
-  <a href="https://goreportcard.com/report/github.com/seborama/govcr/v16">
-    <img src="https://goreportcard.com/badge/github.com/seborama/govcr/v16" alt="govcr">
+  <a href="https://goreportcard.com/report/github.com/seborama/govcr/v17">
+    <img src="https://goreportcard.com/badge/github.com/seborama/govcr/v17" alt="govcr">
   </a>
 </p>
 
@@ -107,7 +107,7 @@ We use a "relaxed" request matcher because `example.com` injects an "`Age`" head
 ## Install
 
 ```bash
-go get github.com/seborama/govcr/v16@latest
+go get github.com/seborama/govcr/v17@latest
 ```
 
 For all available releases, please check the [releases](https://github.com/seborama/govcr/releases) tab on github.
@@ -115,7 +115,7 @@ For all available releases, please check the [releases](https://github.com/sebor
 And your source code would use this import:
 
 ```go
-import "github.com/seborama/govcr/v16"
+import "github.com/seborama/govcr/v17"
 ```
 
 For versions of **govcr** before v5 (which don't use go.mod), use a dependency manager to lock the version you wish to use (perhaps v4)!
@@ -147,7 +147,7 @@ go get gopkg.in/seborama/govcr.v4
 
 Cassette files can be stored on the filesystem or on a cloud storage service (AWS S3), etc.
 
-The code documentation can be found on [godoc](https://pkg.go.dev/github.com/seborama/govcr/v16).
+The code documentation can be found on [godoc](https://pkg.go.dev/github.com/seborama/govcr/v17).
 
 When using **govcr**'s `http.Client`, the request is matched against the **tracks** on the '**cassette**':
 
@@ -450,7 +450,7 @@ vcr := govcr.NewVCR(
 The command is located in the `cmd/govcr` folder, to install it:
 
 ```bash
-go install github.com/seborama/govcr/v16/cmd/govcr@latest
+go install github.com/seborama/govcr/v17/cmd/govcr@latest
 ```
 
 Example usage:

--- a/cassette/cassette.go
+++ b/cassette/cassette.go
@@ -14,12 +14,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
-	"github.com/seborama/govcr/v16/cassette/track"
-	"github.com/seborama/govcr/v16/compression"
-	cryptoerr "github.com/seborama/govcr/v16/encryption/errors"
-	govcrerr "github.com/seborama/govcr/v16/errors"
-	"github.com/seborama/govcr/v16/fileio"
-	"github.com/seborama/govcr/v16/stats"
+	"github.com/seborama/govcr/v17/cassette/track"
+	"github.com/seborama/govcr/v17/compression"
+	cryptoerr "github.com/seborama/govcr/v17/encryption/errors"
+	govcrerr "github.com/seborama/govcr/v17/errors"
+	"github.com/seborama/govcr/v17/fileio"
+	"github.com/seborama/govcr/v17/stats"
 )
 
 // Cassette contains a set of tracks.

--- a/cassette/cassette.go
+++ b/cassette/cassette.go
@@ -29,8 +29,10 @@ type Cassette struct {
 	name            string
 	trackSliceMutex sync.RWMutex
 	tracksLoaded    int32
-	crypter         Crypter
-	store           FileIO
+	// crypter provides an encryption abstraction for cassette read/write operations.
+	crypter Crypter
+	// store provides a storage backend abstraction: file system, cloud storage, etc
+	store FileIO
 }
 
 type FileIO interface {

--- a/cassette/cassette_test.go
+++ b/cassette/cassette_test.go
@@ -248,19 +248,19 @@ type StoreMock struct {
 	Data []byte
 }
 
-func (s *StoreMock) MkdirAll(path string, perm os.FileMode) error {
+func (s *StoreMock) MkdirAll(_ string, _ os.FileMode) error {
 	return nil
 }
 
-func (s *StoreMock) ReadFile(name string) ([]byte, error) {
+func (s *StoreMock) ReadFile(_ string) ([]byte, error) {
 	return nil, nil
 }
 
-func (s *StoreMock) WriteFile(name string, data []byte, perm os.FileMode) error {
+func (s *StoreMock) WriteFile(_ string, data []byte, _ os.FileMode) error {
 	s.Data = data
 	return nil
 }
 
-func (s *StoreMock) NotExist(name string) (bool, error) {
+func (s *StoreMock) NotExist(_ string) (bool, error) {
 	return false, nil
 }

--- a/cassette/cassette_test.go
+++ b/cassette/cassette_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v16/cassette"
-	"github.com/seborama/govcr/v16/cassette/track"
-	"github.com/seborama/govcr/v16/encryption"
+	"github.com/seborama/govcr/v17/cassette"
+	"github.com/seborama/govcr/v17/cassette/track"
+	"github.com/seborama/govcr/v17/encryption"
 )
 
 func Test_cassette_GzipFilter(t *testing.T) {

--- a/cassette/cassette_wb_test.go
+++ b/cassette/cassette_wb_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/seborama/govcr/v16/stats"
+	"github.com/seborama/govcr/v17/stats"
 )
 
 func Test_cassette_NumberOfTracks_PanicsWhenNoCassette(t *testing.T) {

--- a/cassette/track/http.go
+++ b/cassette/track/http.go
@@ -194,7 +194,7 @@ type Response struct {
 	// such as e.g. a transaction ID, a customer number, etc.
 	// This is solely for informational purpose at replaying time.
 	// Mutating it at replay time typically achieves nothing very useful.
-	Request *Request `json:"Request"`
+	Request *Request `json:"-"`
 }
 
 // ToResponse transcodes an HTTP Response to a track Response.

--- a/cassette/track/http_test.go
+++ b/cassette/track/http_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v16/cassette/track"
+	"github.com/seborama/govcr/v17/cassette/track"
 )
 
 func TestRequest_Clone(t *testing.T) {

--- a/cassette/track/mutator_test.go
+++ b/cassette/track/mutator_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v16/cassette/track"
+	"github.com/seborama/govcr/v17/cassette/track"
 )
 
 func Test_Mutator_On(t *testing.T) {

--- a/cassette/track/track.go
+++ b/cassette/track/track.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	trkerr "github.com/seborama/govcr/v16/cassette/track/errors"
+	trkerr "github.com/seborama/govcr/v17/cassette/track/errors"
 )
 
 // Track is a recording (HTTP Request + Response) in a cassette.

--- a/cassette/track/track_test.go
+++ b/cassette/track/track_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v16/cassette/track"
+	"github.com/seborama/govcr/v17/cassette/track"
 )
 
 func TestTrack_ToHTTPResponse(t *testing.T) {

--- a/cmd/govcr/main.go
+++ b/cmd/govcr/main.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/seborama/govcr/v16/cassette"
-	"github.com/seborama/govcr/v16/encryption"
+	"github.com/seborama/govcr/v17/cassette"
+	"github.com/seborama/govcr/v17/encryption"
 )
 
 func main() {

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v16"
-	"github.com/seborama/govcr/v16/stats"
+	"github.com/seborama/govcr/v17"
+	"github.com/seborama/govcr/v17/stats"
 )
 
 func TestConcurrencySafety(t *testing.T) {

--- a/controlpanel.go
+++ b/controlpanel.go
@@ -3,8 +3,8 @@ package govcr
 import (
 	"net/http"
 
-	"github.com/seborama/govcr/v16/cassette/track"
-	"github.com/seborama/govcr/v16/stats"
+	"github.com/seborama/govcr/v17/cassette/track"
+	"github.com/seborama/govcr/v17/stats"
 )
 
 // ControlPanel holds the parts of a VCR that can be interacted with.

--- a/controlpanel_wb_test.go
+++ b/controlpanel_wb_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/seborama/govcr/v16/cassette/track"
+	"github.com/seborama/govcr/v17/cassette/track"
 )
 
 func TestControlPanel_SetRecordingMutators(t *testing.T) {

--- a/encryption/.study/rsa.go
+++ b/encryption/.study/rsa.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 
-	cryptoerr "github.com/seborama/govcr/v16/encryption/errors"
+	cryptoerr "github.com/seborama/govcr/v17/encryption/errors"
 )
 
 // TODO: offer ability to supply the key via an environment variable in base64 format.

--- a/encryption/aesgcm.go
+++ b/encryption/aesgcm.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	cryptoerr "github.com/seborama/govcr/v16/encryption/errors"
+	cryptoerr "github.com/seborama/govcr/v17/encryption/errors"
 )
 
 // NewAESGCMWithRandomNonceGenerator creates a new Cryptor initialised with an

--- a/encryption/aesgcm_test.go
+++ b/encryption/aesgcm_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v16/encryption"
+	"github.com/seborama/govcr/v17/encryption"
 )
 
 func TestCryptor_AESGCM(t *testing.T) {

--- a/encryption/chacha20poly1305_test.go
+++ b/encryption/chacha20poly1305_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v16/encryption"
+	"github.com/seborama/govcr/v17/encryption"
 )
 
 func TestCryptor_ChaCha20Poly1305(t *testing.T) {

--- a/examples/Example1_test.go
+++ b/examples/Example1_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/seborama/govcr/v16"
-	"github.com/seborama/govcr/v16/stats"
+	"github.com/seborama/govcr/v17"
+	"github.com/seborama/govcr/v17/stats"
 )
 
 const exampleCassetteName1 = "temp-fixtures/TestExample1.cassette.json"

--- a/examples/Example2_test.go
+++ b/examples/Example2_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seborama/govcr/v16"
+	"github.com/seborama/govcr/v17"
 )
 
 const exampleCassetteName2 = "temp-fixtures/TestExample2.cassette.json"

--- a/examples/Example3_test.go
+++ b/examples/Example3_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/seborama/govcr/v16"
-	"github.com/seborama/govcr/v16/cassette/track"
+	"github.com/seborama/govcr/v17"
+	"github.com/seborama/govcr/v17/cassette/track"
 	"github.com/stretchr/testify/require"
 )
 

--- a/examples/Example4_test.go
+++ b/examples/Example4_test.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/seborama/govcr/v16"
-	"github.com/seborama/govcr/v16/encryption"
-	"github.com/seborama/govcr/v16/stats"
+	"github.com/seborama/govcr/v17"
+	"github.com/seborama/govcr/v17/encryption"
+	"github.com/seborama/govcr/v17/stats"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/examples/Example5_test.go
+++ b/examples/Example5_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v16"
-	"github.com/seborama/govcr/v16/fileio"
-	"github.com/seborama/govcr/v16/stats"
+	"github.com/seborama/govcr/v17"
+	"github.com/seborama/govcr/v17/fileio"
+	"github.com/seborama/govcr/v17/stats"
 )
 
 // TestExample5 is a simple example use of govcr with a AWS S3 cassette storage.

--- a/fileio/aws_test.go
+++ b/fileio/aws_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v16/fileio"
+	"github.com/seborama/govcr/v17/fileio"
 )
 
 func TestS3Client(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/seborama/govcr/v16
+module github.com/seborama/govcr/v17
 
 go 1.23.0
 

--- a/govcr.go
+++ b/govcr.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/seborama/govcr/v16/cassette"
-	"github.com/seborama/govcr/v16/encryption"
+	"github.com/seborama/govcr/v17/cassette"
+	"github.com/seborama/govcr/v17/encryption"
 )
 
 // CrypterProvider is the signature of a cipher provider function with default nonce generator.

--- a/govcr_test.go
+++ b/govcr_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/seborama/govcr/v16"
-	"github.com/seborama/govcr/v16/cassette"
-	"github.com/seborama/govcr/v16/cassette/track"
-	"github.com/seborama/govcr/v16/encryption"
-	"github.com/seborama/govcr/v16/stats"
+	"github.com/seborama/govcr/v17"
+	"github.com/seborama/govcr/v17/cassette"
+	"github.com/seborama/govcr/v17/cassette/track"
+	"github.com/seborama/govcr/v17/encryption"
+	"github.com/seborama/govcr/v17/stats"
 )
 
 func TestNewVCR(t *testing.T) {

--- a/govcr_test.go
+++ b/govcr_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/seborama/govcr/v16"
+	"github.com/seborama/govcr/v16/cassette"
 	"github.com/seborama/govcr/v16/cassette/track"
 	"github.com/seborama/govcr/v16/encryption"
 	"github.com/seborama/govcr/v16/stats"
@@ -407,6 +408,73 @@ func (ts *GoVCRTestSuite) TestRoundTrip_ReplaysPlainResponse() {
 		TracksPlayed:   2,
 	}
 	ts.Equal(expectedStats, vcr.Stats())
+}
+
+// This test checks that on recording a new track to an existing cassette, the
+// Response.Request of replayed tracks is not persisted from the replay.
+func TestRecordReplayRecord(t *testing.T) {
+	const k7Name = "temp-fixtures/TestRecordReplayRecord.cassette.json"
+
+	_ = os.Remove(k7Name)
+
+	vcr := govcr.NewVCR(
+		govcr.NewCassetteLoader(k7Name),
+		govcr.WithRequestMatchers(govcr.NewMethodURLRequestMatchers()...), // use a "relaxed" request matcher
+	)
+
+	// The first request will be live and transparently recorded by govcr since the cassette is empty
+	vcr.HTTPClient().Get("http://example.com/foo")
+	assert.Equal(
+		t,
+		&stats.Stats{
+			TotalTracks:    1,
+			TracksLoaded:   0,
+			TracksRecorded: 1,
+			TracksPlayed:   0,
+		},
+		vcr.Stats(),
+	)
+	k789 := cassette.LoadCassette(k7Name)
+	assert.Len(t, k789.Tracks, 1)
+	assert.Nil(t, k789.Tracks[0].Response.Request, "the Response.Request is not nil")
+
+	// The second request will be transparently replayed from the cassette by govcr
+	// No live HTTP request is placed to the live server.
+	vcr = govcr.NewVCR(
+		govcr.NewCassetteLoader(k7Name),
+		govcr.WithRequestMatchers(govcr.NewMethodURLRequestMatchers()...), // use a "relaxed" request matcher
+	)
+
+	vcr.HTTPClient().Get("http://example.com/foo")
+	assert.Equal(
+		t,
+		&stats.Stats{
+			TotalTracks:    1,
+			TracksLoaded:   1,
+			TracksRecorded: 0,
+			TracksPlayed:   1,
+		},
+		vcr.Stats(),
+	)
+
+	// The third request will be live and transparently recorded by govcr since no existing
+	// track on the cassette will match.
+	vcr.HTTPClient().Get("http://example.com/foo/bar")
+	assert.Equal(
+		t,
+		&stats.Stats{
+			TotalTracks:    2,
+			TracksLoaded:   1,
+			TracksRecorded: 1,
+			TracksPlayed:   1,
+		},
+		vcr.Stats(),
+	)
+
+	// Verify the 1st cassette track has not recorded Response.Request from the track replay.
+	k7 := cassette.LoadCassette(k7Name)
+	assert.Len(t, k7.Tracks, 2)
+	assert.Nil(t, k7.Tracks[0].Response.Request)
 }
 
 func (ts *GoVCRTestSuite) makeHTTPCallsWithSuccess(httpClient *http.Client, serverCurrentCount int) {

--- a/govcr_wb_test.go
+++ b/govcr_wb_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/seborama/govcr/v16/cassette/track"
-	"github.com/seborama/govcr/v16/stats"
+	"github.com/seborama/govcr/v17/cassette/track"
+	"github.com/seborama/govcr/v17/stats"
 )
 
 type GoVCRWBTestSuite struct {

--- a/matchers.go
+++ b/matchers.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/seborama/govcr/v16/cassette/track"
+	"github.com/seborama/govcr/v17/cassette/track"
 )
 
 // RequestMatcher is a function that performs request comparison.

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/seborama/govcr/v16"
-	"github.com/seborama/govcr/v16/cassette/track"
+	"github.com/seborama/govcr/v17"
+	"github.com/seborama/govcr/v17/cassette/track"
 )
 
 func Test_DefaultHeaderMatcher(t *testing.T) {

--- a/pcb.go
+++ b/pcb.go
@@ -3,8 +3,8 @@ package govcr
 import (
 	"net/http"
 
-	"github.com/seborama/govcr/v16/cassette"
-	"github.com/seborama/govcr/v16/cassette/track"
+	"github.com/seborama/govcr/v17/cassette"
+	"github.com/seborama/govcr/v17/cassette/track"
 )
 
 // HTTPMode defines govcr's mode for HTTP requests.

--- a/pcb_wb_test.go
+++ b/pcb_wb_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/seborama/govcr/v16/cassette"
-	"github.com/seborama/govcr/v16/cassette/track"
+	"github.com/seborama/govcr/v17/cassette"
+	"github.com/seborama/govcr/v17/cassette/track"
 )
 
 //nolint:gocognit

--- a/vcrsettings.go
+++ b/vcrsettings.go
@@ -3,8 +3,8 @@ package govcr
 import (
 	"net/http"
 
-	"github.com/seborama/govcr/v16/cassette"
-	"github.com/seborama/govcr/v16/cassette/track"
+	"github.com/seborama/govcr/v17/cassette"
+	"github.com/seborama/govcr/v17/cassette/track"
 )
 
 // Setting defines an optional functional parameter as received by NewVCR().

--- a/vcrtransport.go
+++ b/vcrtransport.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/seborama/govcr/v16/cassette"
-	"github.com/seborama/govcr/v16/cassette/track"
-	"github.com/seborama/govcr/v16/encryption"
-	govcrerr "github.com/seborama/govcr/v16/errors"
-	"github.com/seborama/govcr/v16/stats"
+	"github.com/seborama/govcr/v17/cassette"
+	"github.com/seborama/govcr/v17/cassette/track"
+	"github.com/seborama/govcr/v17/encryption"
+	govcrerr "github.com/seborama/govcr/v17/errors"
+	"github.com/seborama/govcr/v17/stats"
 )
 
 // vcrTransport is the heart of VCR. It implements


### PR DESCRIPTION
> [!NOTE]
> !This PR is the continuation of @callebjorkell's https://github.com/seborama/govcr/pull/116
> I needed to resolve conflicts and add a test.

---

Add a `json:"-"` struct tag to the Response.Request field, to make sure this field is never saved to disk.

This fixes a case where the Response.Request field is populated during a replay, and then a new track is added, causing the cassette to be re-saved to disk, including the request field.

This case is especially problematic in cases where a `TrackRecordingMutator` has been used to remove sensitive information from the request, since the nested request was not covered by the mutator.

Please, ensure your pull request meet these guidelines:

- [x] My code is written in TDD (test driven development) fashion.
- [x] My code adheres to Go standards
      I have run `make lint`,
      or I have used https://goreportcard.com/
      and I have taken the necessary compliance actions.
- [ ] I have provided / updated examples.
- [ ] I have updated [README.md].

Thanks for your PR, you're awesome! :+1:
